### PR TITLE
Export util components for custom page objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,9 +22,9 @@
     "release:minor": "npm run release -- minor",
     "release:major": "npm run release -- major",
     "test": "run-s test:*",
+    "test:setup": "cd node_modules && rm -rf ./wdio-vscode-service && ln -s ../ wdio-vscode-service && cd ..",
     "test:lint": "eslint src test example",
     "test:e2e": "run-s test:e2e:*",
-    "test:e2e:setup": "cd node_modules && rm -rf ./wdio-vscode-service && ln -s ../ wdio-vscode-service && cd ..",
     "test:e2e:run": "wdio run ./test/wdio.conf.ts",
     "watch": "yarn run build --watch"
   },

--- a/src/pageobjects/index.ts
+++ b/src/pageobjects/index.ts
@@ -1,13 +1,28 @@
+export * from './activityBar/ActivityBar'
+export * from './activityBar/ViewControl'
+export * from './activityBar/ActionsControl'
+
+export * from './bottomBar/BottomBarPanel'
+export * from './bottomBar/ProblemsView'
+export * from './bottomBar/Views'
+
+export * from './dialog/ModalDialog'
+
+export * from './editor/EditorView'
+export * from './editor/TextEditor'
+export * from './editor/Editor'
+export * from './editor/SettingsEditor'
+export * from './editor/DiffEditor'
+export * from './editor/WebView'
+export * from './editor/ContentAssist'
+export * from './editor/CustomEditor'
+
 export * from './menu/Menu'
 export * from './menu/MenuItem'
 export * from './menu/TitleBar'
 export * from './menu/MacTitleBar'
 export * from './menu/ContextMenu'
 export * from './menu/WindowControls'
-
-export * from './activityBar/ActivityBar'
-export * from './activityBar/ViewControl'
-export * from './activityBar/ActionsControl'
 
 export * from './sidebar/SideBarView'
 export * from './sidebar/ViewTitlePart'
@@ -26,19 +41,7 @@ export { ScmView, ScmProvider, ScmChange } from './sidebar/scm/ScmView'
 export * from './sidebar/scm/NewScmView'
 export * from './sidebar/debug/DebugView'
 
-export * from './bottomBar/BottomBarPanel'
-export * from './bottomBar/ProblemsView'
-export * from './bottomBar/Views'
 export * from './statusBar/StatusBar'
-
-export * from './editor/EditorView'
-export * from './editor/TextEditor'
-export * from './editor/Editor'
-export * from './editor/SettingsEditor'
-export * from './editor/DiffEditor'
-export * from './editor/WebView'
-export * from './editor/ContentAssist'
-export * from './editor/CustomEditor'
 
 export * from './workbench/Workbench'
 export { Notification, NotificationType } from './workbench/Notification'
@@ -46,4 +49,4 @@ export * from './workbench/NotificationsCenter'
 export * from './workbench/Input'
 export * from './workbench/DebugToolbar'
 
-export * from './dialog/ModalDialog'
+export * from './utils'

--- a/src/pageobjects/index.ts
+++ b/src/pageobjects/index.ts
@@ -1,28 +1,13 @@
-export * from './activityBar/ActivityBar'
-export * from './activityBar/ViewControl'
-export * from './activityBar/ActionsControl'
-
-export * from './bottomBar/BottomBarPanel'
-export * from './bottomBar/ProblemsView'
-export * from './bottomBar/Views'
-
-export * from './dialog/ModalDialog'
-
-export * from './editor/EditorView'
-export * from './editor/TextEditor'
-export * from './editor/Editor'
-export * from './editor/SettingsEditor'
-export * from './editor/DiffEditor'
-export * from './editor/WebView'
-export * from './editor/ContentAssist'
-export * from './editor/CustomEditor'
-
 export * from './menu/Menu'
 export * from './menu/MenuItem'
 export * from './menu/TitleBar'
 export * from './menu/MacTitleBar'
 export * from './menu/ContextMenu'
 export * from './menu/WindowControls'
+
+export * from './activityBar/ActivityBar'
+export * from './activityBar/ViewControl'
+export * from './activityBar/ActionsControl'
 
 export * from './sidebar/SideBarView'
 export * from './sidebar/ViewTitlePart'
@@ -41,7 +26,19 @@ export { ScmView, ScmProvider, ScmChange } from './sidebar/scm/ScmView'
 export * from './sidebar/scm/NewScmView'
 export * from './sidebar/debug/DebugView'
 
+export * from './bottomBar/BottomBarPanel'
+export * from './bottomBar/ProblemsView'
+export * from './bottomBar/Views'
 export * from './statusBar/StatusBar'
+
+export * from './editor/EditorView'
+export * from './editor/TextEditor'
+export * from './editor/Editor'
+export * from './editor/SettingsEditor'
+export * from './editor/DiffEditor'
+export * from './editor/WebView'
+export * from './editor/ContentAssist'
+export * from './editor/CustomEditor'
 
 export * from './workbench/Workbench'
 export { Notification, NotificationType } from './workbench/Notification'

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -1,7 +1,14 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../dist/service.d.ts" />
 
+import { PluginDecorator, BasePage } from 'wdio-vscode-service'
+
 describe('WDIO VSCode Service', () => {
+    it('exports necessary components for custom pageobjects', () => {
+        expect(typeof PluginDecorator).toBe('function')
+        expect(typeof BasePage).toBe('function')
+    })
+
     it('should be able to load VSCode', async () => {
         const workbench = await browser.getWorkbench()
         expect(await workbench.getTitleBar().getTitle())


### PR DESCRIPTION
The page object model developed for VSCode can be also very useful when building your own page objects. Let's export them and add some docs on how they can be used.