### PR TITLE
Allow verbose logging for VSCode extension host

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
     "wdio-chromedriver-service": "^7.3.2"
   },
   "peerDependencies": {
-    "webdriverio": "^7.19.1"
+    "webdriverio": "^7.19.2"
   },
   "peerDependenciesMeta": {
     "webdriverio": {

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,8 +8,8 @@ export const VSCODE_APPLICATION_ARGS = [
     '--disable-updates',
     '--skip-welcome',
     '--skip-release-notes',
-    '--disable-workspace-trust'
-    // '--disable-extensions'
+    '--disable-workspace-trust',
+    '--disable-extensions'
 ]
 export const DEFAULT_VSCODE_SETTINGS = {
     'window.titleBarStyle': 'custom',

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -8,8 +8,8 @@ export const VSCODE_APPLICATION_ARGS = [
     '--disable-updates',
     '--skip-welcome',
     '--skip-release-notes',
-    '--disable-workspace-trust',
-    '--disable-extensions'
+    '--disable-workspace-trust'
+    // '--disable-extensions'
 ]
 export const DEFAULT_VSCODE_SETTINGS = {
     'window.titleBarStyle': 'custom',

--- a/src/pageobjects/workbench/Notification.ts
+++ b/src/pageobjects/workbench/Notification.ts
@@ -1,5 +1,7 @@
 import { ChainablePromiseElement } from 'webdriverio'
-import { BasePage, IPluginDecorator, VSCodeLocatorMap } from '../utils'
+import {
+    BasePage, IPluginDecorator, PluginDecorator, VSCodeLocatorMap
+} from '../utils'
 import { Notification as NotificationLocators } from '../../locators/1.61.0'
 
 /**
@@ -145,6 +147,7 @@ export abstract class Notification extends BasePage<typeof NotificationLocators>
  *
  * @category Workbench
  */
+@PluginDecorator(NotificationLocators)
 export class StandaloneNotification extends Notification {
     /**
      * @private
@@ -164,6 +167,7 @@ export class StandaloneNotification extends Notification {
  *
  * @category Workbench
  */
+@PluginDecorator(NotificationLocators)
 export class CenterNotification extends Notification {
     /**
      * @private

--- a/src/pageobjects/workbench/Workbench.ts
+++ b/src/pageobjects/workbench/Workbench.ts
@@ -73,22 +73,26 @@ export class Workbench extends BasePage<typeof WorkbenchLocators> {
      */
     async getNotifications (): Promise<Notification[]> {
         const notifications: Notification[] = []
-        const container = await this.notificationContainer$
+        const containers = await this.notificationContainer$$
 
-        if (!await container.isExisting()) {
+        if (containers.length === 0) {
             return []
         }
-        const elements = await container.$$(this.locators.notificationItem)
 
-        for (const element of elements) {
-            notifications.push(
-                await new StandaloneNotification(
-                    this.locatorMap,
-                    // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                    element as any
-                ).wait()
-            )
+        for (const container of containers) {
+            const elements = await container.$$(this.locators.notificationItem)
+
+            for (const element of elements) {
+                notifications.push(
+                    await new StandaloneNotification(
+                        this.locatorMap,
+                        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+                        element as any
+                    ).wait()
+                )
+            }
         }
+
         return notifications
     }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -55,6 +55,7 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             ].filter(Boolean),
             windowTypes: ['webview']
         }
+        console.log(JSON.stringify(capabilities, null, 4))
     }
 
     async before (capabilities: ServiceCapabilities, __: never, browser: WebdriverIO.Browser) {

--- a/src/service.ts
+++ b/src/service.ts
@@ -14,11 +14,8 @@ const log = logger('wdio-vscode-service')
 
 export default class VSCodeWorkerService implements Services.ServiceInstance {
     private _browser?: WebdriverIO.Browser
-    private _verboseLogging: boolean
 
-    constructor (private _options: ServiceOptions) {
-        this._verboseLogging = typeof this._options.verboseLogging === 'undefined' || this._options.verboseLogging
-    }
+    constructor (private _options: ServiceOptions) {}
 
     async beforeSession (_: Options.Testrunner, capabilities: ServiceCapabilities) {
         const customArgs: string[] = []
@@ -48,7 +45,7 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             customArgs.push(`--file-uri=${this._options.filePath}`)
         }
 
-        if (this._verboseLogging) {
+        if (this._options.verboseLogging) {
             customArgs.push('--verbose', '--logExtensionHostCommunication')
         }
 
@@ -65,7 +62,6 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             ].filter(Boolean),
             windowTypes: ['webview']
         }
-        console.log(JSON.stringify(capabilities, null, 4))
     }
 
     async before (capabilities: ServiceCapabilities, __: never, browser: WebdriverIO.Browser) {
@@ -81,7 +77,7 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
     }
 
     async after () {
-        if (!this._browser || !this._verboseLogging) {
+        if (!this._browser || !this._options.verboseLogging) {
             return
         }
 

--- a/src/service.ts
+++ b/src/service.ts
@@ -41,15 +41,15 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         )
 
         if (this._options.workspacePath) {
-            customArgs.push(`--folder-uri=${this._options.workspacePath}`)
+            customArgs.push(`folder-uri=${this._options.workspacePath}`)
         }
 
         if (this._options.filePath) {
-            customArgs.push(`--file-uri=${this._options.filePath}`)
+            customArgs.push(`file-uri=${this._options.filePath}`)
         }
 
         if (this._verboseLogging) {
-            customArgs.push('--verbose', '--logExtensionHostCommunication')
+            customArgs.push('verbose', 'logExtensionHostCommunication')
         }
 
         capabilities.browserName = 'chrome'
@@ -57,8 +57,8 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             binary: capabilities['wdio:vscodeService'].vscode.path,
             args: [
                 ...VSCODE_APPLICATION_ARGS,
-                `--extensionDevelopmentPath=${this._options.extensionPath}`,
-                `--user-data-dir=${path.join(storagePath.path, 'settings')}`,
+                `extensionDevelopmentPath=${this._options.extensionPath}`,
+                `user-data-dir=${path.join(storagePath.path, 'settings')}`,
                 ...customArgs,
                 ...(this._options.args || [])
             ].filter(Boolean),

--- a/src/service.ts
+++ b/src/service.ts
@@ -41,15 +41,15 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         )
 
         if (this._options.workspacePath) {
-            customArgs.push(`folder-uri=${this._options.workspacePath}`)
+            customArgs.push(`--folder-uri=${this._options.workspacePath}`)
         }
 
         if (this._options.filePath) {
-            customArgs.push(`file-uri=${this._options.filePath}`)
+            customArgs.push(`--file-uri=${this._options.filePath}`)
         }
 
         if (this._verboseLogging) {
-            customArgs.push('verbose', 'logExtensionHostCommunication')
+            customArgs.push('--verbose', '--logExtensionHostCommunication')
         }
 
         capabilities.browserName = 'chrome'
@@ -57,8 +57,9 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             binary: capabilities['wdio:vscodeService'].vscode.path,
             args: [
                 ...VSCODE_APPLICATION_ARGS,
-                `extensionDevelopmentPath=${this._options.extensionPath}`,
-                `user-data-dir=${path.join(storagePath.path, 'settings')}`,
+                `--extensionDevelopmentPath=${this._options.extensionPath}`,
+                `--user-data-dir=${path.join(storagePath.path, 'settings')}`,
+                `--extensions-dir=${path.join(storagePath.path, 'extensions')}`,
                 ...customArgs,
                 ...(this._options.args || [])
             ].filter(Boolean),

--- a/src/types.ts
+++ b/src/types.ts
@@ -40,6 +40,13 @@ export interface ServiceOptions extends ChromedriverServiceOptions {
      * Additional start-up arguments
      */
     args?: string[]
+    /**
+     * If set to true, service logs VSCode output from the extension host
+     * and console API
+     *
+     * @default `true`
+     */
+    verboseLogging?: boolean
 }
 
 export interface BundleInformation {
@@ -54,4 +61,11 @@ export interface ServiceCapability {
 
 export interface ServiceCapabilities extends Capabilities.Capabilities {
     'wdio:vscodeService': ServiceCapability
+}
+
+export interface WDIOLogs {
+    level: string
+    message: string
+    source: string
+    timestamp: number
 }

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -47,6 +47,17 @@ describe('WDIO VSCode Service', () => {
         expect(title).toContain('wdio-vscode-service')
     })
 
+    it('is able to read guinea pig notification', async () => {
+        const workbench = await browser.getWorkbench()
+        await browser.waitUntil(async () => {
+            const notifs = await workbench.getNotifications()
+            const messages = await Promise.all(notifs.map((n) => n.getMessage()))
+            return messages.includes('Hello World')
+        }, {
+            timeoutMsg: 'Could not find test extension notification'
+        })
+    })
+
     describe('activity bar', () => {
         it('should show all activity bar items', async () => {
             const workbench = await browser.getWorkbench()

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -52,7 +52,7 @@ describe('WDIO VSCode Service', () => {
         await browser.waitUntil(async () => {
             const notifs = await workbench.getNotifications()
             const messages = await Promise.all(notifs.map((n) => n.getMessage()))
-            return messages.includes('Hello World')
+            return messages.includes('Hello World!')
         }, {
             timeoutMsg: 'Could not find test extension notification'
         })

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -5,6 +5,8 @@ import {
     PluginDecorator, IPluginDecorator, BasePage, BottomBarPanel
 } from '../..'
 
+const skipWindows = process.platform === 'win32' ? it.skip : it
+
 const locators = {
     marquee: {
         elem: 'ul[aria-label="Active View Switcher"]',
@@ -46,7 +48,7 @@ describe('WDIO VSCode Service', () => {
         expect(title).toContain('wdio-vscode-service')
     })
 
-    it('is able to read guinea pig notification', async () => {
+    skipWindows('is able to read guinea pig notification', async () => {
         const workbench = await browser.getWorkbench()
         await browser.waitUntil(async () => {
             const notifs = await workbench.getNotifications()

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -2,8 +2,7 @@
 /// <reference path="../../dist/service.d.ts" />
 
 import {
-    PluginDecorator, IPluginDecorator, BasePage, BottomBarPanel,
-    ExtensionsViewSection
+    PluginDecorator, IPluginDecorator, BasePage, BottomBarPanel
 } from '../..'
 
 const locators = {

--- a/yarn.lock
+++ b/yarn.lock
@@ -361,9 +361,9 @@
     "@types/istanbul-lib-report" "*"
 
 "@types/json-schema@^7.0.9":
-  version "7.0.10"
-  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.10.tgz#9b05b7896166cd00e9cbd59864853abf65d9ac23"
-  integrity sha512-BLO9bBq59vW3fxCpD4o0N4U+DXsvwvIcl+jofw0frQo/GrBFC+/jRZj1E7kgp6dvTyNmA4y6JCV5Id/r3mNP5A==
+  version "7.0.11"
+  resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.11.tgz#d421b6c527a3037f7c84433fd2c4229e016863d3"
+  integrity sha512-wOuvG1SN4Us4rez+tylwwwCV1psiNVOkJeM3AUWUNWg/jDQY2+HE/444y5gc+jBmRqASOm2Oeh5c1axHobwRKQ==
 
 "@types/json5@^0.0.29":
   version "0.0.29"
@@ -496,13 +496,13 @@
     "@types/node" "*"
 
 "@typescript-eslint/eslint-plugin@^5.14.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.16.0.tgz#78f246dd8d1b528fc5bfca99a8a64d4023a3d86d"
-  integrity sha512-SJoba1edXvQRMmNI505Uo4XmGbxCK9ARQpkvOd00anxzri9RNQk0DDCxD+LIl+jYhkzOJiOMMKYEHnHEODjdCw==
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-5.17.0.tgz#704eb4e75039000531255672bf1c85ee85cf1d67"
+  integrity sha512-qVstvQilEd89HJk3qcbKt/zZrfBZ+9h2ynpAGlWjWiizA7m/MtLT9RoX6gjtpE500vfIg8jogAkDzdCxbsFASQ==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.16.0"
-    "@typescript-eslint/type-utils" "5.16.0"
-    "@typescript-eslint/utils" "5.16.0"
+    "@typescript-eslint/scope-manager" "5.17.0"
+    "@typescript-eslint/type-utils" "5.17.0"
+    "@typescript-eslint/utils" "5.17.0"
     debug "^4.3.2"
     functional-red-black-tree "^1.0.1"
     ignore "^5.1.8"
@@ -521,13 +521,13 @@
     debug "^4.3.1"
 
 "@typescript-eslint/parser@^5.14.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.16.0.tgz#e4de1bde4b4dad5b6124d3da227347616ed55508"
-  integrity sha512-fkDq86F0zl8FicnJtdXakFs4lnuebH6ZADDw6CYQv0UZeIjHvmEw87m9/29nk2Dv5Lmdp0zQ3zDQhiMWQf/GbA==
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-5.17.0.tgz#7def77d5bcd8458d12d52909118cf3f0a45f89d5"
+  integrity sha512-aRzW9Jg5Rlj2t2/crzhA2f23SIYFlF9mchGudyP0uiD6SenIxzKoLjwzHbafgHn39dNV/TV7xwQkLfFTZlJ4ig==
   dependencies:
-    "@typescript-eslint/scope-manager" "5.16.0"
-    "@typescript-eslint/types" "5.16.0"
-    "@typescript-eslint/typescript-estree" "5.16.0"
+    "@typescript-eslint/scope-manager" "5.17.0"
+    "@typescript-eslint/types" "5.17.0"
+    "@typescript-eslint/typescript-estree" "5.17.0"
     debug "^4.3.2"
 
 "@typescript-eslint/scope-manager@4.33.0":
@@ -538,20 +538,20 @@
     "@typescript-eslint/types" "4.33.0"
     "@typescript-eslint/visitor-keys" "4.33.0"
 
-"@typescript-eslint/scope-manager@5.16.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.16.0.tgz#7e7909d64bd0c4d8aef629cdc764b9d3e1d3a69a"
-  integrity sha512-P+Yab2Hovg8NekLIR/mOElCDPyGgFZKhGoZA901Yax6WR6HVeGLbsqJkZ+Cvk5nts/dAlFKm8PfL43UZnWdpIQ==
+"@typescript-eslint/scope-manager@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-5.17.0.tgz#4cea7d0e0bc0e79eb60cad431c89120987c3f952"
+  integrity sha512-062iCYQF/doQ9T2WWfJohQKKN1zmmXVfAcS3xaiialiw8ZUGy05Em6QVNYJGO34/sU1a7a+90U3dUNfqUDHr3w==
   dependencies:
-    "@typescript-eslint/types" "5.16.0"
-    "@typescript-eslint/visitor-keys" "5.16.0"
+    "@typescript-eslint/types" "5.17.0"
+    "@typescript-eslint/visitor-keys" "5.17.0"
 
-"@typescript-eslint/type-utils@5.16.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.16.0.tgz#b482bdde1d7d7c0c7080f7f2f67ea9580b9e0692"
-  integrity sha512-SKygICv54CCRl1Vq5ewwQUJV/8padIWvPgCxlWPGO/OgQLCijY9G7lDu6H+mqfQtbzDNlVjzVWQmeqbLMBLEwQ==
+"@typescript-eslint/type-utils@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-5.17.0.tgz#1c4549d68c89877662224aabb29fbbebf5fc9672"
+  integrity sha512-3hU0RynUIlEuqMJA7dragb0/75gZmwNwFf/QJokWzPehTZousP/MNifVSgjxNcDCkM5HI2K22TjQWUmmHUINSg==
   dependencies:
-    "@typescript-eslint/utils" "5.16.0"
+    "@typescript-eslint/utils" "5.17.0"
     debug "^4.3.2"
     tsutils "^3.21.0"
 
@@ -560,10 +560,10 @@
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-4.33.0.tgz#a1e59036a3b53ae8430ceebf2a919dc7f9af6d72"
   integrity sha512-zKp7CjQzLQImXEpLt2BUw1tvOMPfNoTAfb8l51evhYbOEEzdWyQNmHWWGPR6hwKJDAi+1VXSBmnhL9kyVTTOuQ==
 
-"@typescript-eslint/types@5.16.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.16.0.tgz#5827b011982950ed350f075eaecb7f47d3c643ee"
-  integrity sha512-oUorOwLj/3/3p/HFwrp6m/J2VfbLC8gjW5X3awpQJ/bSG+YRGFS4dpsvtQ8T2VNveV+LflQHjlLvB6v0R87z4g==
+"@typescript-eslint/types@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-5.17.0.tgz#861ec9e669ffa2aa9b873dd4d28d9b1ce26d216f"
+  integrity sha512-AgQ4rWzmCxOZLioFEjlzOI3Ch8giDWx8aUDxyNw9iOeCvD3GEYAB7dxWGQy4T/rPVe8iPmu73jPHuaSqcjKvxw==
 
 "@typescript-eslint/typescript-estree@4.33.0":
   version "4.33.0"
@@ -578,28 +578,28 @@
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/typescript-estree@5.16.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.16.0.tgz#32259459ec62f5feddca66adc695342f30101f61"
-  integrity sha512-SE4VfbLWUZl9MR+ngLSARptUv2E8brY0luCdgmUevU6arZRY/KxYoLI/3V/yxaURR8tLRN7bmZtJdgmzLHI6pQ==
+"@typescript-eslint/typescript-estree@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-5.17.0.tgz#a7cba7dfc8f9cc2ac78c18584e684507df4f2488"
+  integrity sha512-X1gtjEcmM7Je+qJRhq7ZAAaNXYhTgqMkR10euC4Si6PIjb+kwEQHSxGazXUQXFyqfEXdkGf6JijUu5R0uceQzg==
   dependencies:
-    "@typescript-eslint/types" "5.16.0"
-    "@typescript-eslint/visitor-keys" "5.16.0"
+    "@typescript-eslint/types" "5.17.0"
+    "@typescript-eslint/visitor-keys" "5.17.0"
     debug "^4.3.2"
     globby "^11.0.4"
     is-glob "^4.0.3"
     semver "^7.3.5"
     tsutils "^3.21.0"
 
-"@typescript-eslint/utils@5.16.0", "@typescript-eslint/utils@^5.10.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.16.0.tgz#42218b459d6d66418a4eb199a382bdc261650679"
-  integrity sha512-iYej2ER6AwmejLWMWzJIHy3nPJeGDuCqf8Jnb+jAQVoPpmWzwQOfa9hWVB8GIQE5gsCv/rfN4T+AYb/V06WseQ==
+"@typescript-eslint/utils@5.17.0", "@typescript-eslint/utils@^5.10.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-5.17.0.tgz#549a9e1d491c6ccd3624bc3c1b098f5cfb45f306"
+  integrity sha512-DVvndq1QoxQH+hFv+MUQHrrWZ7gQ5KcJzyjhzcqB1Y2Xes1UQQkTRPUfRpqhS8mhTWsSb2+iyvDW1Lef5DD7vA==
   dependencies:
     "@types/json-schema" "^7.0.9"
-    "@typescript-eslint/scope-manager" "5.16.0"
-    "@typescript-eslint/types" "5.16.0"
-    "@typescript-eslint/typescript-estree" "5.16.0"
+    "@typescript-eslint/scope-manager" "5.17.0"
+    "@typescript-eslint/types" "5.17.0"
+    "@typescript-eslint/typescript-estree" "5.17.0"
     eslint-scope "^5.1.1"
     eslint-utils "^3.0.0"
 
@@ -611,12 +611,12 @@
     "@typescript-eslint/types" "4.33.0"
     eslint-visitor-keys "^2.0.0"
 
-"@typescript-eslint/visitor-keys@5.16.0":
-  version "5.16.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.16.0.tgz#f27dc3b943e6317264c7492e390c6844cd4efbbb"
-  integrity sha512-jqxO8msp5vZDhikTwq9ubyMHqZ67UIvawohr4qF3KhlpL7gzSjOd+8471H3nh5LyABkaI85laEKKU8SnGUK5/g==
+"@typescript-eslint/visitor-keys@5.17.0":
+  version "5.17.0"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-5.17.0.tgz#52daae45c61b0211b4c81b53a71841911e479128"
+  integrity sha512-6K/zlc4OfCagUu7Am/BD5k8PSWQOgh34Nrv9Rxe2tBzlJ7uOeJ/h7ugCGDCeEZHT6k2CJBhbk9IsbkPI0uvUkA==
   dependencies:
-    "@typescript-eslint/types" "5.16.0"
+    "@typescript-eslint/types" "5.17.0"
     eslint-visitor-keys "^3.0.0"
 
 "@ungap/promise-all-settled@1.1.2":
@@ -635,9 +635,9 @@
     unzipper "^0.10.11"
 
 "@wdio/cli@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-7.19.1.tgz#c9ca99cd9b013491a8053f6151a149ab34b2e72b"
-  integrity sha512-6e6cZ5xerj5VEJDn+fbobGjPaoGi55jsfJnSacU5sb1J+oCK5baGz5OKUjVsFOxAoD62CNW4euSk3zp7nLs8Tg==
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/@wdio/cli/-/cli-7.19.2.tgz#dc3d9833feb9a7cdd0ab062449a3747c95fc371c"
+  integrity sha512-lWrpTn/suuno3Kb0IAN/vruLXvjGxwmA/ND8Sn0okwRAzKDABtZ63pNfXNg/DDzGIG1ZIEbPixTQE0BBqJ0usA==
   dependencies:
     "@types/ejs" "^3.0.5"
     "@types/fs-extra" "^9.0.4"
@@ -650,20 +650,20 @@
     "@wdio/config" "7.19.1"
     "@wdio/logger" "7.19.0"
     "@wdio/types" "7.19.1"
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
     async-exit-hook "^2.0.1"
     chalk "^4.0.0"
     chokidar "^3.0.0"
     cli-spinners "^2.1.0"
     ejs "^3.0.1"
     fs-extra "^10.0.0"
-    inquirer "8.1.5"
+    inquirer "8.2.2"
     lodash.flattendeep "^4.4.0"
     lodash.pickby "^4.6.0"
     lodash.union "^4.6.0"
     mkdirp "^1.0.4"
     recursive-readdir "^2.2.2"
-    webdriverio "7.19.1"
+    webdriverio "7.19.2"
     yargs "^17.0.0"
     yarn-install "^1.0.0"
 
@@ -678,14 +678,14 @@
     glob "^7.1.2"
 
 "@wdio/local-runner@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@wdio/local-runner/-/local-runner-7.19.1.tgz#dc3976cde752f8ed7b25bf8de4c49e8f95f1afd2"
-  integrity sha512-nYGGv5tD2xrB2JEvry48V50D51DaV+ZNuD/w2620NcIWTT7i0gD82SnRNTJi18dSy4K7wcaV+mFCJyC2kNVNUw==
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/@wdio/local-runner/-/local-runner-7.19.2.tgz#304b00fc83eae76784dbf09c1cd145e814ae947d"
+  integrity sha512-MwSeeVrv8k+Q4SDOS+ver1TJ87GSohCGwB0DpPZuyHjFU2oJ+q6DpK6nSoJA8QTOYBk34SG10Ogz59DV2Y2i5Q==
   dependencies:
     "@types/stream-buffers" "^3.0.3"
     "@wdio/logger" "7.19.0"
-    "@wdio/repl" "7.19.1"
-    "@wdio/runner" "7.19.1"
+    "@wdio/repl" "7.19.2"
+    "@wdio/runner" "7.19.2"
     "@wdio/types" "7.19.1"
     async-exit-hook "^2.0.1"
     split2 "^4.0.0"
@@ -702,14 +702,14 @@
     strip-ansi "^6.0.0"
 
 "@wdio/mocha-framework@^7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@wdio/mocha-framework/-/mocha-framework-7.19.1.tgz#c2bd26eb661aa323ff28fbd2921841346962b838"
-  integrity sha512-cM4C8QuZpsAE5DK0kEJa81IIyrq2uJQ0RgyM6ef/BlldrdRzEF9dBE5bv3Ho60wvVd574HpNnicKjxcIjdQgug==
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/@wdio/mocha-framework/-/mocha-framework-7.19.2.tgz#d2a3021fd9f540702a3fc6c216bae09e487879e3"
+  integrity sha512-FOHtj40lYp1zr3NJsAQsjYrKTjEcayI/NV7hdyvKTsG1xgWEHhJoyqN9G20DPUBsASICkK6wklx4PcEXHD4qvg==
   dependencies:
     "@types/mocha" "^9.0.0"
     "@wdio/logger" "7.19.0"
     "@wdio/types" "7.19.1"
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
     expect-webdriverio "^3.0.0"
     mocha "^9.0.0"
 
@@ -718,12 +718,12 @@
   resolved "https://registry.yarnpkg.com/@wdio/protocols/-/protocols-7.19.0.tgz#cd753752c64b9c1dd7ace05398c1d11c46af41ab"
   integrity sha512-ji74rQag6v+INSNd0J8eAh2rpH5vOXgeiP5Qr32K6PWU6HzYWuAFH2x4srXsH0JawHCdTK2OQAOYrLmMb44hug==
 
-"@wdio/repl@7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-7.19.1.tgz#17944422a9e7bfceea731f92624bab67f2eb6833"
-  integrity sha512-FQwIkSA7b9agZOV5IXqLMGsvzFqmJ3CVbDovjkFq92RtUKI27lwz5IC4ipRdGPhp0lvgw0u2sUXeqlS9tkrG4w==
+"@wdio/repl@7.19.2":
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/@wdio/repl/-/repl-7.19.2.tgz#7fa54035823b2231622794d2e4f97f3704e51e97"
+  integrity sha512-BjgRkEcx6tMPLweOLJLpa/jZ/8JeCxFyIEPwJecVa4mVvV8Sjkhbrbnn9Zhy18w1bulQXgmkBPDnwXZxFjT1lQ==
   dependencies:
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
 
 "@wdio/reporter@7.19.1":
   version "7.19.1"
@@ -741,19 +741,19 @@
     object-inspect "^1.10.3"
     supports-color "8.1.1"
 
-"@wdio/runner@7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@wdio/runner/-/runner-7.19.1.tgz#edc8097c05025625f5b504b1ea4ab32855c6d3af"
-  integrity sha512-jMrzRfyD1/dYNPdfCMQfhKWZKF5apM/uDajXDWDJNyyWciwOvAJ8AyBc69FbpKCy1hdaabl4flY/sspvU6BwoQ==
+"@wdio/runner@7.19.2":
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/@wdio/runner/-/runner-7.19.2.tgz#100f1c606657860bd575c92208ddca600f0b366f"
+  integrity sha512-FKXgID6sLABaIIzc3bTuf1L7jxiaFAluEKB7fl38gdZMDR31/2wuGkd5vyd+25DG7msgnbQhmxG3YoSB+NOAlA==
   dependencies:
     "@wdio/config" "7.19.1"
     "@wdio/logger" "7.19.0"
     "@wdio/types" "7.19.1"
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
     deepmerge "^4.0.0"
     gaze "^1.1.2"
-    webdriver "7.19.1"
-    webdriverio "7.19.1"
+    webdriver "7.19.2"
+    webdriverio "7.19.2"
 
 "@wdio/spec-reporter@^7.19.1":
   version "7.19.1"
@@ -775,10 +775,10 @@
     "@types/node" "^17.0.4"
     got "^11.8.1"
 
-"@wdio/utils@7.19.1":
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-7.19.1.tgz#e436959518e7effa1c2420bfc13793f94f6c2d28"
-  integrity sha512-Uynr6kUcXDjFqVlI7rgfcuUHGA7M1t+ICjc3R+Evr5cktBj2G8jb4S0SG0tGOPw9p7u5M49iyPy14oxTcb3aPw==
+"@wdio/utils@7.19.2":
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/@wdio/utils/-/utils-7.19.2.tgz#d87084c90f52130050bb0322f15803c7a19b2443"
+  integrity sha512-zO1YvPVJEAYZ4Q6aIV9nKZ8gHmFCndJJpoj5TLGjHVPrHBG0QRaw7rZZ1ajt6FtKG7uMOzOjeX5XW94DHK3A7Q==
   dependencies:
     "@wdio/logger" "7.19.0"
     "@wdio/types" "7.19.1"
@@ -1089,7 +1089,7 @@ brace-expansion@^2.0.1:
   dependencies:
     balanced-match "^1.0.0"
 
-braces@^3.0.1, braces@~3.0.2:
+braces@^3.0.2, braces@~3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/braces/-/braces-3.0.2.tgz#3454e1a462ee8d599e236df336cd9ea4f8afe107"
   integrity sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
@@ -1727,10 +1727,10 @@ devtools-protocol@^0.0.982423:
   resolved "https://registry.yarnpkg.com/devtools-protocol/-/devtools-protocol-0.0.982423.tgz#39ac3791d4c5b90ebb416d4384663b7b0cc44154"
   integrity sha512-FnVW2nDbjGNw1uD/JRC+9U5768W7e1TfUwqbDTcSsAu1jXFjITSX8w3rkW5FEpHRMPPGpvNSmO1pOpqByiWscA==
 
-devtools@7.19.1:
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/devtools/-/devtools-7.19.1.tgz#2f9c87b34692867908d09dc21e12aa32dbd91bc6"
-  integrity sha512-wDBEF+kOY+eyv2yRYsWM0c4KHi89E95+LOMZLbpjWY8GcKRZ74Vu94i7T9OgLrd6osrZStiDc75RN4X0XOjFwQ==
+devtools@7.19.2:
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/devtools/-/devtools-7.19.2.tgz#35084c13bef6bcb0f53bc6fac2322ae23da816e8"
+  integrity sha512-lbgO3/1Ged1zlJM2VFa8iuIFUw0gjT2FQ1sPn4S9mjT7viXux7pY1Vq3xn4TXRBA8zACF2T25UljiJYKpVIUTA==
   dependencies:
     "@types/node" "^17.0.4"
     "@types/ua-parser-js" "^0.7.33"
@@ -1738,7 +1738,7 @@ devtools@7.19.1:
     "@wdio/logger" "7.19.0"
     "@wdio/protocols" "7.19.0"
     "@wdio/types" "7.19.1"
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
     chrome-launcher "^0.15.0"
     edge-paths "^2.1.0"
     puppeteer-core "^13.1.3"
@@ -1862,9 +1862,9 @@ error-ex@^1.2.0, error-ex@^1.3.1:
     is-arrayish "^0.2.1"
 
 es-abstract@^1.19.0, es-abstract@^1.19.1:
-  version "1.19.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.1.tgz#d4885796876916959de78edaa0df456627115ec3"
-  integrity sha512-2vJ6tjA/UfqLm2MPs7jxVybLoB8i1t1Jd9R3kISld20sIxPcTbLuggQOUxeWeAvIUkduv/CfMjuh4WmiXr2v9w==
+  version "1.19.2"
+  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.19.2.tgz#8f7b696d8f15b167ae3640b4060670f3d054143f"
+  integrity sha512-gfSBJoZdlL2xRiOCy0g8gLMryhoe1TlimjzU99L/31Z8QEGIhVQI+EWwt5lT+AuU9SnorVupXFqqOGqGfsyO6w==
   dependencies:
     call-bind "^1.0.2"
     es-to-primitive "^1.2.1"
@@ -1872,15 +1872,15 @@ es-abstract@^1.19.0, es-abstract@^1.19.1:
     get-intrinsic "^1.1.1"
     get-symbol-description "^1.0.0"
     has "^1.0.3"
-    has-symbols "^1.0.2"
+    has-symbols "^1.0.3"
     internal-slot "^1.0.3"
     is-callable "^1.2.4"
-    is-negative-zero "^2.0.1"
+    is-negative-zero "^2.0.2"
     is-regex "^1.1.4"
     is-shared-array-buffer "^1.0.1"
     is-string "^1.0.7"
-    is-weakref "^1.0.1"
-    object-inspect "^1.11.0"
+    is-weakref "^1.0.2"
+    object-inspect "^1.12.0"
     object-keys "^1.1.1"
     object.assign "^4.1.2"
     string.prototype.trimend "^1.0.4"
@@ -2077,9 +2077,9 @@ eslint-visitor-keys@^3.0.0, eslint-visitor-keys@^3.3.0:
   integrity sha512-mQ+suqKJVyeuwGYHAdjMFqjCyfl8+Ldnxuyp3ldiMBFKkvytrXUZWaiPCEav8qDHKty44bD+qV1IP4T+w+xXRA==
 
 eslint@^8.10.0:
-  version "8.11.0"
-  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.11.0.tgz#88b91cfba1356fc10bb9eb592958457dfe09fb37"
-  integrity sha512-/KRpd9mIRg2raGxHRGwW9ZywYNAClZrHjdueHcrVDuO3a6bj83eoTirCCk0M0yPwOjWYKHwRVRid+xK4F/GHgA==
+  version "8.12.0"
+  resolved "https://registry.yarnpkg.com/eslint/-/eslint-8.12.0.tgz#c7a5bd1cfa09079aae64c9076c07eada66a46e8e"
+  integrity sha512-it1oBL9alZg1S8UycLm5YDMAkIhtH6FtAzuZs6YvoGVldWjbS08BkAdb/ymP9LlAyq8koANu32U7Ib/w+UNh8Q==
   dependencies:
     "@eslint/eslintrc" "^1.2.1"
     "@humanwhocodes/config-array" "^0.9.2"
@@ -2763,7 +2763,7 @@ has-symbol-support-x@^1.4.1:
   resolved "https://registry.yarnpkg.com/has-symbol-support-x/-/has-symbol-support-x-1.4.2.tgz#1409f98bc00247da45da67cee0a36f282ff26455"
   integrity sha512-3ToOva++HaW+eCpgqZrCfN51IPB+7bJNVT6CUATzueB5Heb8o6Nam0V3HG5dlDvZU1Gn5QLcbahiKw/XVk5JJw==
 
-has-symbols@^1.0.1, has-symbols@^1.0.2:
+has-symbols@^1.0.1, has-symbols@^1.0.2, has-symbols@^1.0.3:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/has-symbols/-/has-symbols-1.0.3.tgz#bb7b2c4349251dce87b125f7bdf874aa7c8b39f8"
   integrity sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==
@@ -2936,26 +2936,6 @@ ini@~1.3.0:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-inquirer@8.1.5:
-  version "8.1.5"
-  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.1.5.tgz#2dc5159203c826d654915b5fe6990fd17f54a150"
-  integrity sha512-G6/9xUqmt/r+UvufSyrPpt84NYwhKZ9jLsgMbQzlx804XErNupor8WQdBnBRrXmBfTPpuwf1sV+ss2ovjgdXIg==
-  dependencies:
-    ansi-escapes "^4.2.1"
-    chalk "^4.1.1"
-    cli-cursor "^3.1.0"
-    cli-width "^3.0.0"
-    external-editor "^3.0.3"
-    figures "^3.0.0"
-    lodash "^4.17.21"
-    mute-stream "0.0.8"
-    ora "^5.4.1"
-    run-async "^2.4.0"
-    rxjs "^7.2.0"
-    string-width "^4.1.0"
-    strip-ansi "^6.0.0"
-    through "^2.3.6"
-
 inquirer@8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.0.tgz#f44f008dd344bbfc4b30031f45d984e034a3ac3a"
@@ -2972,6 +2952,26 @@ inquirer@8.2.0:
     ora "^5.4.1"
     run-async "^2.4.0"
     rxjs "^7.2.0"
+    string-width "^4.1.0"
+    strip-ansi "^6.0.0"
+    through "^2.3.6"
+
+inquirer@8.2.2:
+  version "8.2.2"
+  resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.2.tgz#1310517a87a0814d25336c78a20b44c3d9b7629d"
+  integrity sha512-pG7I/si6K/0X7p1qU+rfWnpTE1UIkTONN1wxtzh0d+dHXtT/JG6qBgLxoyHVsQa8cFABxAPh0pD6uUUHiAoaow==
+  dependencies:
+    ansi-escapes "^4.2.1"
+    chalk "^4.1.1"
+    cli-cursor "^3.1.0"
+    cli-width "^3.0.0"
+    external-editor "^3.0.3"
+    figures "^3.0.0"
+    lodash "^4.17.21"
+    mute-stream "0.0.8"
+    ora "^5.4.1"
+    run-async "^2.4.0"
+    rxjs "^7.5.5"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
     through "^2.3.6"
@@ -3103,7 +3103,7 @@ is-natural-number@^4.0.1:
   resolved "https://registry.yarnpkg.com/is-natural-number/-/is-natural-number-4.0.1.tgz#ab9d76e1db4ced51e35de0c72ebecf09f734cde8"
   integrity sha1-q5124dtM7VHjXeDHLr7PCfc0zeg=
 
-is-negative-zero@^2.0.1:
+is-negative-zero@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.2.tgz#7bf6f03a28003b8b3965de3ac26f664d765f3150"
   integrity sha512-dqJvarLawXsFbNDeJW7zAz8ItJ9cd28YufuuFzh0G8pNHjJMnY08Dv7sYX2uF5UpQOwieAeOExEYAWWfu7ZZUA==
@@ -3229,7 +3229,7 @@ is-utf8@^0.2.0:
   resolved "https://registry.yarnpkg.com/is-utf8/-/is-utf8-0.2.1.tgz#4b0da1442104d1b336340e80797e865cf39f7d72"
   integrity sha1-Sw2hRCEE0bM2NA6AeX6GXPOffXI=
 
-is-weakref@^1.0.1:
+is-weakref@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/is-weakref/-/is-weakref-1.0.2.tgz#9529f383a9338205e89765e0392efc2f100f06f2"
   integrity sha512-qctsuLZmIQ0+vSSMfoVvyFe2+GSEvnmZ2ezTup1SBse9+twCCeial6EEi3Nc2KFcf6+qz2FBPnjXsk8xhKSaPQ==
@@ -3673,12 +3673,12 @@ merge2@^1.3.0, merge2@^1.4.1:
   integrity sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
 
 micromatch@^4.0.4:
-  version "4.0.4"
-  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.4.tgz#896d519dfe9db25fce94ceb7a500919bf881ebf9"
-  integrity sha512-pRmzw/XUcwXGpD9aI9q/0XOwLNygjETJ8y0ao0wdqprrzDa4YnxLcz7fQRZr8voh8V10kGhABbNcHVk5wHgWwg==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/micromatch/-/micromatch-4.0.5.tgz#bc8999a7cbbf77cdc89f132f6e467051b49090c6"
+  integrity sha512-DMy+ERcEW2q8Z2Po+WNXuw3c5YaUSFjAO5GsJqfEl7UjvtIuFKO6ZrKvcItdy98dwFI2N1tg3zNIdKaQT+aNdA==
   dependencies:
-    braces "^3.0.1"
-    picomatch "^2.2.3"
+    braces "^3.0.2"
+    picomatch "^2.3.1"
 
 mime-db@1.51.0:
   version "1.51.0"
@@ -3923,7 +3923,7 @@ object-assign@^4.0.1, object-assign@^4.1.0:
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
   integrity sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
 
-object-inspect@^1.10.3, object-inspect@^1.11.0, object-inspect@^1.9.0:
+object-inspect@^1.10.3, object-inspect@^1.12.0, object-inspect@^1.9.0:
   version "1.12.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.0.tgz#6e2c120e868fd1fd18cb4f18c31741d0d6e776f0"
   integrity sha512-Ho2z80bVIvJloH+YzRmpZVQe87+qASmBUKZDWgx9cu+KDrX2ZDH/3tMy+gXbZETVGs2M8YdxObOh7XAtim9Y0g==
@@ -4256,7 +4256,7 @@ pend@~1.2.0:
   resolved "https://registry.yarnpkg.com/pend/-/pend-1.2.0.tgz#7a57eb550a6783f9115331fcf4663d5c8e007a50"
   integrity sha1-elfrVQpng/kRUzH89GY9XI4AelA=
 
-picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.2.3:
+picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
@@ -4686,7 +4686,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-rxjs@^7.2.0:
+rxjs@^7.2.0, rxjs@^7.5.5:
   version "7.5.5"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.5.5.tgz#2ebad89af0f560f460ad5cc4213219e1f7dd4e9f"
   integrity sha512-sy+H0pQofO95VDmFLzyaw9xNJU4KTRSwQIGM6+iG3SypAtCiLDzpeG8sJrNCWn2Up9km+KhkvTdbkrdy+yzZdw==
@@ -5253,9 +5253,9 @@ typedoc@^0.22.13:
     shiki "^0.10.1"
 
 typescript@^4.6.2:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.2.tgz#fe12d2727b708f4eef40f51598b3398baa9611d4"
-  integrity sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==
+  version "4.6.3"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.6.3.tgz#eefeafa6afdd31d725584c67a0eaba80f6fc6c6c"
+  integrity sha512-yNIatDa5iaofVozS/uQJEl3JRWLKKGJKh6Yaiv0GLGSuhpFJe7P3SbHZ8/yjAHRQwKRoA6YZqlfjXWmVzoVSMw==
 
 ua-parser-js@^1.0.1:
   version "1.0.2"
@@ -5417,39 +5417,39 @@ wdio-chromedriver-service@^7.3.2:
     split2 "^3.2.2"
     tcp-port-used "^1.0.1"
 
-webdriver@7.19.1:
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-7.19.1.tgz#6c139fb6b79aa2670f5284f9f70b9256513ae488"
-  integrity sha512-lyTmrtSIadFpuAOQ/1/TUQkfbbBLQSm5jLeuP77L6ttAuGL+xIrtWYWtqMqSBWZXBeX/QSZKVNzX6XbElWCCbw==
+webdriver@7.19.2:
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/webdriver/-/webdriver-7.19.2.tgz#e190dc03f02e5406234a88c0daeee75f7954d0f7"
+  integrity sha512-hQ9v1ivif4yCZ42TkRI/aReUjE/JaLz99AyPP4GZHDPVlzOV81D4ChYvth3P39HLR1fHFXkenyi6baFhGbZPLQ==
   dependencies:
     "@types/node" "^17.0.4"
     "@wdio/config" "7.19.1"
     "@wdio/logger" "7.19.0"
     "@wdio/protocols" "7.19.0"
     "@wdio/types" "7.19.1"
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
     got "^11.0.2"
     ky "^0.30.0"
     lodash.merge "^4.6.1"
 
-webdriverio@7.19.1:
-  version "7.19.1"
-  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.19.1.tgz#75c11ddd42afd5433f4add45d58f258158ab0acc"
-  integrity sha512-/MCeiS8fRv8Tg7OWS8DxD3oHBAjMalDTk5oZU+g8YynldhMDXK69JY+uJ+CJ1qjW+mcHwMME1gWRcaHh7tm8fw==
+webdriverio@7.19.2:
+  version "7.19.2"
+  resolved "https://registry.yarnpkg.com/webdriverio/-/webdriverio-7.19.2.tgz#457b6027acb77524375c93145df0cf2121c87031"
+  integrity sha512-1cQN7j+FmPA7M/1LjMThb51gbWkcgT1M2Y+Z6sztkRXxJBtcfSjSjaVPnA32O103QiQKQmE2kVj7FuQPD1ixOQ==
   dependencies:
     "@types/aria-query" "^5.0.0"
     "@types/node" "^17.0.4"
     "@wdio/config" "7.19.1"
     "@wdio/logger" "7.19.0"
     "@wdio/protocols" "7.19.0"
-    "@wdio/repl" "7.19.1"
+    "@wdio/repl" "7.19.2"
     "@wdio/types" "7.19.1"
-    "@wdio/utils" "7.19.1"
+    "@wdio/utils" "7.19.2"
     archiver "^5.0.0"
     aria-query "^5.0.0"
     css-shorthand-properties "^1.1.1"
     css-value "^0.0.1"
-    devtools "7.19.1"
+    devtools "7.19.2"
     devtools-protocol "^0.0.982423"
     fs-extra "^10.0.0"
     get-port "^5.1.1"
@@ -5464,7 +5464,7 @@ webdriverio@7.19.1:
     resq "^1.9.1"
     rgb2hex "0.2.5"
     serialize-error "^8.0.0"
-    webdriver "7.19.1"
+    webdriver "7.19.2"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
This patch adds an option to have the service log all logs from VSCode and the extension host into stdout (or `outputDir` if defined).