### PR TITLE
Run tests on more VSCode versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        vscodeVersion:
+          - insiders
+          - stable
+          - 1.65.0
     runs-on: ${{ matrix.os }}
 
     steps:
@@ -29,6 +33,8 @@ jobs:
         uses: GabrielBB/xvfb-action@v1
         with:
           run: yarn test
+        env:
+          VSCODE_VERSION: ${{ matrix.vscodeVersion }}
       - uses: actions/upload-artifact@v3
         if: failure()
         with:

--- a/src/locators/insiders.ts
+++ b/src/locators/insiders.ts
@@ -1,0 +1,10 @@
+import {
+    QuickOpenBox as QuickOpenBoxImport
+} from './1.66.0'
+
+export * from './1.66.0'
+export const locatorVersion = 'insiders'
+export const QuickOpenBox = {
+    ...QuickOpenBoxImport,
+    elem: '.quick-input-widget'
+}

--- a/src/pageobjects/utils.ts
+++ b/src/pageobjects/utils.ts
@@ -1,6 +1,6 @@
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
 
-import * as allLocatorsTypes from '../locators/1.61.0'
+import * as allLocatorsTypes from '../locators/insiders'
 import { ContextMenu } from '..'
 
 type ClassWithFunctionLocatorsAsString<T> = {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -56,6 +56,10 @@ export function validatePlatform () {
 }
 
 export async function getLocators (version: string): Promise<VSCodeLocatorMap> {
+    if (version === 'insiders') {
+        return import('./locators/insiders') as any as Promise<VSCodeLocatorMap>
+    }
+
     const files = (await fs.readdir(path.join(__dirname, 'locators'), { encoding: 'utf-8' }))
         .filter((filename) => filename.endsWith('.js') && !filename.endsWith('.d.ts'))
         .map((filename) => filename.slice(0, -3))

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -62,7 +62,11 @@ export async function getLocators (version: string): Promise<VSCodeLocatorMap> {
 
     const [major, minor] = version.split('.')
     const sanitizedVersion = `${major}.${minor}.0`
-    const locatorFile = files.find((f) => f >= sanitizedVersion) || files[files.length - 1]
+
+    const locatorFile = files.find((f, i) => (
+        f === sanitizedVersion
+        || (files[i + 1] && files[i + 1] > sanitizedVersion)
+    )) || files[files.length - 1]
     return import(`./locators/${locatorFile}`) as Promise<VSCodeLocatorMap>
 }
 

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -81,7 +81,8 @@ export const config: Options.Testrunner = {
     // https://saucelabs.com/platform/platform-configurator
     //
     capabilities: [{
-        browserName: 'chrome'
+        browserName: 'VSCode',
+        browserVersion: process.env.VSCODE_VERSION || 'stable'
     }],
     //
     // ===================
@@ -131,6 +132,7 @@ export const config: Options.Testrunner = {
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
     services: [['vscode', {
+        vscode: { version: process.env.VSCODE_VERSION || 'stable' },
         extensionPath: path.join(__dirname, 'extension'),
         workspacePath: path.join(__dirname, '..'),
         filePath: path.join(__dirname, '..', 'README.md')

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -81,8 +81,7 @@ export const config: Options.Testrunner = {
     // https://saucelabs.com/platform/platform-configurator
     //
     capabilities: [{
-        browserName: 'VSCode',
-        browserVersion: process.env.VSCODE_VERSION || 'stable'
+        browserName: 'chrome'
     }],
     //
     // ===================


### PR DESCRIPTION
We want to make sure that we test our page objects for multiple VSCode versions. This PR is a first attempt to set up the infrastructure for it.