### PR TITLE
Multiremote Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For more information on how to install `WebdriverIO`, please check the [project 
 
 ## Example Configuration
 
-To use the service you need to add `vscode` to your services array, followed by a configuration object:
+To use the service you need to add `vscode` to your list of services, optionally followed by a configuration object:
 
 ```js
 // wdio.conf.ts
@@ -56,6 +56,11 @@ export const config = {
         }
     }],
     services: ['vscode'],
+    /**
+     * optionally you can define the path WebdriverIO stores all
+     * VSCode and Chromedriver binaries, e.g.:
+     * services: [['vscode', { cachePath: __dirname }]]
+     */
     // ...
 };
 ```
@@ -115,14 +120,7 @@ Through service configuration you can manage the VSCode version as well as user 
 
 ### Service Options
 
-Service options are options needed for the service to setup the test environment.
-
-#### `args`
-
-Additional Chromedriver arguments (see `chromedriver --help` for more information)
-
-Type: `string[]`<br />
-Default: `[]`
+Service options are options needed for the service to setup the test environment. They are a superset of the [Chromedriver options](https://webdriver.io/docs/wdio-chromedriver-service#options) which can be applied for this service as well.
 
 #### `cachePath`
 

--- a/README.md
+++ b/README.md
@@ -45,17 +45,17 @@ To use the service you need to add `vscode` to your services array, followed by 
 export const config = {
     outputDir: 'trace',
     // ...
-    services: [
-        ['vscode', {
+    capabilities: [{
+        browserName: 'vscode',
+        browserVersion: '1.66.0' // "insiders" or "stable" for latest VSCode version
+        'wdio:vscodeOptions': {
             extensionPath: __dirname,
-            vscode: {
-                version: 'insiders' // or "stable" for latest VSCode version
-            },
             userSettings: {
                 "editor.fontSize": 14
             }
-        }]
-    ],
+        }
+    }],
+    services: ['vscode'],
     // ...
 };
 ```
@@ -113,53 +113,60 @@ For the full page object documentation, check out the [docs](https://webdriverio
 
 Through service configuration you can manage the VSCode version as well as user settings for VSCode:
 
-### `vscode`
+### Service Options
 
-Define which VSCode application should be used for testing.
+Service options are options needed for the service to setup the test environment.
 
-Type: `ServiceDownloadOptions`<br />
-Default: `{ version: "stable" }`
-
-### `cachePath`
-
-Define a cache path to avoid re-downloading all bundles. This is useful for CI/CD to avoid re-downloading VSCode and Chromedriver for every testrun.
-
-Type: `string`<br />
-Default: `process.cwd()`
-
-### `extensionPath`
-
-Define the directory to the extension you want to test.
-
-Type: `string`
-
-### `userSettings`
-
-Define custom user settings to be applied to VSCode.
-
-Type: `Record<string, number | string | object | boolean>`<br />
-Default: `{}`
-
-### `workspacePath`
-
-Opens VSCode for a specific workspace. If not provided VSCode starts without a workspace opened.
-
-Type: `string`
-
-### `filePath`
-
-Opens VSCode with a specific file opened.
-
-Type: `string`
-
-### `args`
+#### `args`
 
 Additional Chromedriver arguments (see `chromedriver --help` for more information)
 
 Type: `string[]`<br />
 Default: `[]`
 
-### `vscodeArgs`
+#### `cachePath`
+
+Define a cache path to avoid re-downloading all bundles. This is useful for CI/CD to avoid re-downloading VSCode and Chromedriver for every testrun.
+
+Type: `string`<br />
+Default: `process.cwd()`
+
+### VSCode Capabilities (`wdio:vscodeOptions`)
+
+In order to run tests through VSCode you have to define `vscode` as `browserName`. You can specify the VSCode version by providing a `browserVersion` capability. Custom VSCode options are then defined within the custom `wdio:vscodeOptions` capability. The options are the following:
+
+#### `binary`
+
+Path to a local installed VSCode installation. If option is not provided the service will download VSCode based on given `browserVersion` (or `stable` if not given).
+
+Type: `string`
+
+#### `extensionPath`
+
+Define the directory to the extension you want to test.
+
+Type: `string`
+
+#### `userSettings`
+
+Define custom user settings to be applied to VSCode.
+
+Type: `Record<string, number | string | object | boolean>`<br />
+Default: `{}`
+
+#### `workspacePath`
+
+Opens VSCode for a specific workspace. If not provided VSCode starts without a workspace opened.
+
+Type: `string`
+
+#### `filePath`
+
+Opens VSCode with a specific file opened.
+
+Type: `string`
+
+#### `vscodeArgs`
 
 Additional start-up arguments as object, e.g.
 
@@ -176,14 +183,14 @@ will be passed in as:
 Type: `Record<string, string | boolean>`<br />
 Default: see [`constants.ts#L5-L14`](https://github.com/webdriverio-community/wdio-vscode-service/blob/196a69be3ac2fb82d9c7e4f19a2a1c8ccbaec1e2/src/constants.ts#L5-L14)
 
-### `verboseLogging`
+#### `verboseLogging`
 
 If set to true, service logs VSCode output from the extension host and console API.
 
 Type: `boolean`<br />
 Default: `false`
 
-### `vscodeProxyOptions`
+#### `vscodeProxyOptions`
 
 VSCode API proxy configurations define how WebdriverIO connects to the VSCode workbench to give you access to the VSCode API.
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -75,6 +75,11 @@ export default class VSCodeServiceLauncher extends ChromedriverServiceLauncher {
                 cap['wdio:vscodeOptions'] = <VSCodeOptions>{}
             }
 
+            /**
+             * need to rename capability back to Chrome otherwise Chromedriver
+             * as well as the service won't recognise this capability
+             */
+            cap.browserName = 'chrome'
             const version = cap.browserVersion || DEFAULT_CHANNEL
 
             if (versionsFileExist) {
@@ -91,7 +96,7 @@ export default class VSCodeServiceLauncher extends ChromedriverServiceLauncher {
                         + `and Chromedriver v${content[version]?.chromedriver} already exist`
                     )
 
-                    cap['wdio:vscodeOptions'].binary = vscodePath
+                    cap['wdio:vscodeOptions'].binary = await this._setupVSCode(content[version]!.vscode)
                     this.chromedriverCustomPath = chromedriverPath
                     continue
                 }
@@ -154,7 +159,7 @@ export default class VSCodeServiceLauncher extends ChromedriverServiceLauncher {
      */
     private async _setupVSCode (version: string) {
         try {
-            log.info('Download VSCode (stable)')
+            log.info(`Download VSCode (${version})`)
             return await download({
                 cachePath: this._cachePath,
                 version

--- a/src/service.ts
+++ b/src/service.ts
@@ -122,7 +122,6 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         )
         capabilities.browserName = 'chrome'
         capabilities['goog:chromeOptions'] = { binary, args, windowTypes: ['webview'] }
-        delete capabilities.browserVersion
         log.info(`Start VSCode: ${binary} ${args.join(' ')}`)
     }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -33,15 +33,11 @@ export type ArgsParams = Record<string, string | boolean>
 /**
  * wdio-vscode-service options
  */
-export interface ServiceOptions extends Omit<ChromedriverServiceOptions, 'args'> {
+export interface ServiceOptions extends ChromedriverServiceOptions {
     /**
      * Define a cache path to avoid re-downloading all bundles
      */
     cachePath?: string
-    /**
-     * Additional Chromedriver arguments (see `chromedriver --help` for more information)
-     */
-    args?: string[]
 }
 
 export interface BundleInformation {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,12 +1,5 @@
 import type { ChromedriverServiceOptions } from 'wdio-chromedriver-service'
-import type { DownloadOptions } from '@vscode/test-electron/out/download'
 import type { Capabilities } from '@wdio/types'
-
-export type VSCodeChannel = 'stable' | 'insiders'
-
-export interface ServiceDownloadOptions extends Omit<DownloadOptions, 'version'> {
-    version: VSCodeChannel
-}
 
 /**
  * Settings to handle VSCode Proxy API
@@ -42,13 +35,33 @@ export type ArgsParams = Record<string, string | boolean>
  */
 export interface ServiceOptions extends Omit<ChromedriverServiceOptions, 'args'> {
     /**
-     * Define which VSCode application should be used for testing
-     */
-    vscode?: ServiceDownloadOptions
-    /**
      * Define a cache path to avoid re-downloading all bundles
      */
     cachePath?: string
+    /**
+     * Additional Chromedriver arguments (see `chromedriver --help` for more information)
+     */
+    args?: string[]
+}
+
+export interface BundleInformation {
+    version: string
+    path: string
+}
+
+export interface ServiceCapability {
+    vscode: BundleInformation
+    chromedriver: BundleInformation
+}
+
+/**
+ * Options to manage VSCode session as part of session capability
+ */
+export interface VSCodeOptions {
+    /**
+     * Path to custom VSCode installation
+     */
+    binary: string
     /**
      * Define the directory to the extension you want to test
      */
@@ -65,10 +78,6 @@ export interface ServiceOptions extends Omit<ChromedriverServiceOptions, 'args'>
      * Opens VSCode with a specific file opened
      */
     filePath?: string
-    /**
-     * Additional Chromedriver arguments (see `chromedriver --help` for more information)
-     */
-    args?: string[]
     /**
      * Additional start-up arguments as object, e.g.
      * ```
@@ -93,18 +102,8 @@ export interface ServiceOptions extends Omit<ChromedriverServiceOptions, 'args'>
     vscodeProxyOptions: Partial<VSCodeProxyOptions>
 }
 
-export interface BundleInformation {
-    version: string
-    path: string
-}
-
-export interface ServiceCapability {
-    vscode: BundleInformation
-    chromedriver: BundleInformation
-}
-
-export interface ServiceCapabilities extends Capabilities.Capabilities {
-    'wdio:vscodeService': ServiceCapability
+export interface VSCodeCapabilities extends Capabilities.Capabilities {
+    'wdio:vscodeOptions'?: VSCodeOptions
 }
 
 export interface WDIOLogs {

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -1,6 +1,7 @@
 import fs from 'fs/promises'
 import path from 'path'
 import type { Options } from '@wdio/types'
+import type { VSCodeCapabilities } from '../dist/types'
 
 export const config: Options.Testrunner = {
     //
@@ -81,8 +82,15 @@ export const config: Options.Testrunner = {
     // https://saucelabs.com/platform/platform-configurator
     //
     capabilities: [{
-        browserName: 'chrome'
-    }],
+        browserName: 'vscode',
+        browserVersion: process.env.VSCODE_VERSION || 'stable',
+        'wdio:vscodeOptions': {
+            extensionPath: path.join(__dirname, 'extension'),
+            workspacePath: path.join(__dirname, '..'),
+            filePath: path.join(__dirname, '..', 'README.md')
+            // verboseLogging: true
+        }
+    } as VSCodeCapabilities],
     //
     // ===================
     // Test Configurations
@@ -130,13 +138,7 @@ export const config: Options.Testrunner = {
     // Services take over a specific job you don't want to take care of. They enhance
     // your test setup with almost no effort. Unlike plugins, they don't add new
     // commands. Instead, they hook themselves up into the test process.
-    services: [['vscode', {
-        vscode: { version: process.env.VSCODE_VERSION || 'stable' },
-        extensionPath: path.join(__dirname, 'extension'),
-        workspacePath: path.join(__dirname, '..'),
-        filePath: path.join(__dirname, '..', 'README.md')
-        // verboseLogging: true
-    }]],
+    services: ['vscode'],
 
     // Framework you want to run your specs with.
     // The following are supported: Mocha, Jasmine, and Cucumber


### PR DESCRIPTION
For writing tests for [VSCode Live Server](https://github.com/ritwickdey/vscode-live-server) we need to be able to control both, browser and VSCode, to test their interaction. This can be nicely done with WebdriverIOs multiremote capabilities. Currently this is not supported. I suggest that the service requires the following caps:

```js
{
     browserName: "vscode",
     browserVersion: "insiders"
}
```

rather than defining this through the service options. Then only run the service if these capabilities are given for that capability.