### PR TITLE
Rename PluginDecorator to PageDecorator

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,10 +236,10 @@ Now you can create a page object as following:
 
 ```ts
 // e.g. in /test/pageobjects/loginForm.ts
-import { PluginDecorator, IPluginDecorator, BasePage } from 'wdio-vscode-service'
+import { PageDecorator, IPageDecorator, BasePage } from 'wdio-vscode-service'
 import * as locatorMap, { componentA as componentALocators } from './locators'
-export interface LoginForm extends IPluginDecorator<typeof componentALocators> {}
-@PluginDecorator(componentALocators)
+export interface LoginForm extends IPageDecorator<typeof componentALocators> {}
+@PageDecorator(componentALocators)
 export class LoginForm extends BasePage<typeof componentALocators, typeof locatorMap> {
     /**
      * @private locator key to identify locator map (see locators.ts)

--- a/src/pageobjects/activityBar/ActivityBar.ts
+++ b/src/pageobjects/activityBar/ActivityBar.ts
@@ -1,14 +1,14 @@
 import { ViewControl, ActionsControl } from '..'
-import { PluginDecorator, IPluginDecorator, ElementWithContextMenu } from '../utils'
+import { PageDecorator, IPageDecorator, ElementWithContextMenu } from '../utils'
 import { ActivityBar as ActivityBarLocators } from '../../locators/1.61.0'
 
-export interface ActivityBar extends IPluginDecorator<typeof ActivityBarLocators> {}
+export interface ActivityBar extends IPageDecorator<typeof ActivityBarLocators> {}
 /**
  * Page object representing the left side activity bar in VS Code
  *
  * @category ActivityBar
  */
-@PluginDecorator(ActivityBarLocators)
+@PageDecorator(ActivityBarLocators)
 export class ActivityBar extends ElementWithContextMenu<typeof ActivityBarLocators> {
     /**
      * @private

--- a/src/pageobjects/activityBar/ViewControl.ts
+++ b/src/pageobjects/activityBar/ViewControl.ts
@@ -6,11 +6,11 @@ import {
 import { NewScmView } from '../sidebar/scm/NewScmView'
 
 import {
-    PluginDecorator, IPluginDecorator, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, ElementWithContextMenu, VSCodeLocatorMap
 } from '../utils'
 import { ViewControl as ViewControlLocators } from '../../locators/1.61.0'
 
-export interface ViewControl extends IPluginDecorator<typeof ViewControlLocators> { }
+export interface ViewControl extends IPageDecorator<typeof ViewControlLocators> { }
 /**
  * Page object representing a view container item in the activity bar
  *
@@ -29,7 +29,7 @@ export interface ViewControl extends IPluginDecorator<typeof ViewControlLocators
  *
  * @category ActivityBar
  */
-@PluginDecorator(ViewControlLocators)
+@PageDecorator(ViewControlLocators)
 export class ViewControl extends ElementWithContextMenu<typeof ViewControlLocators> {
     /**
      * @private

--- a/src/pageobjects/bottomBar/BottomBarPanel.ts
+++ b/src/pageobjects/bottomBar/BottomBarPanel.ts
@@ -2,10 +2,10 @@ import {
     DebugConsoleView, OutputView, TerminalView, ProblemsView, EditorView, TitleBar,
     StatusBar
 } from '..'
-import { BasePage, PluginDecorator, IPluginDecorator } from '../utils'
+import { BasePage, PageDecorator, IPageDecorator } from '../utils'
 import { BottomBarPanel as BottomBarPanelLocators } from '../../locators/1.61.0'
 
-export interface BottomBarPanel extends IPluginDecorator<typeof BottomBarPanelLocators> {}
+export interface BottomBarPanel extends IPageDecorator<typeof BottomBarPanelLocators> {}
 /**
  * Page object for the bottom view panel
  *
@@ -16,7 +16,7 @@ export interface BottomBarPanel extends IPluginDecorator<typeof BottomBarPanelLo
  *
  * @category BottomBar
  */
-@PluginDecorator(BottomBarPanelLocators)
+@PageDecorator(BottomBarPanelLocators)
 export class BottomBarPanel extends BasePage<typeof BottomBarPanelLocators> {
     /**
      * @private

--- a/src/pageobjects/bottomBar/ProblemsView.ts
+++ b/src/pageobjects/bottomBar/ProblemsView.ts
@@ -2,11 +2,11 @@ import type { ChainablePromiseElement } from 'webdriverio'
 
 import { BottomBarPanel } from '..'
 import {
-    BasePage, ElementWithContextMenu, PluginDecorator, IPluginDecorator, VSCodeLocatorMap
+    BasePage, ElementWithContextMenu, PageDecorator, IPageDecorator, VSCodeLocatorMap
 } from '../utils'
 import { ProblemsView as ProblemsViewLocators, Marker as MarkerLocators } from '../../locators/1.61.0'
 
-export interface ProblemsView extends IPluginDecorator<typeof ProblemsViewLocators> {}
+export interface ProblemsView extends IPageDecorator<typeof ProblemsViewLocators> {}
 /**
  * Problems view in the bottom panel.
  *
@@ -18,7 +18,7 @@ export interface ProblemsView extends IPluginDecorator<typeof ProblemsViewLocato
  *
  * @category BottomBar
  */
-@PluginDecorator(ProblemsViewLocators)
+@PageDecorator(ProblemsViewLocators)
 export class ProblemsView extends BasePage<typeof ProblemsViewLocators> {
     /**
      * @private
@@ -91,13 +91,13 @@ export class ProblemsView extends BasePage<typeof ProblemsViewLocators> {
     }
 }
 
-export interface Marker extends IPluginDecorator<typeof MarkerLocators> {}
+export interface Marker extends IPageDecorator<typeof MarkerLocators> {}
 /**
  * Page object for marker in problems view
  *
  * @category BottomBar
  */
-@PluginDecorator(MarkerLocators)
+@PageDecorator(MarkerLocators)
 export class Marker extends ElementWithContextMenu<typeof MarkerLocators> {
     /**
      * @private
@@ -150,13 +150,13 @@ export class Marker extends ElementWithContextMenu<typeof MarkerLocators> {
     }
 }
 
-export interface Problem extends IPluginDecorator<typeof MarkerLocators> {}
+export interface Problem extends IPageDecorator<typeof MarkerLocators> {}
 /**
  * Page object for marker in problems view
  *
  * @category BottomBar
  */
-@PluginDecorator(MarkerLocators)
+@PageDecorator(MarkerLocators)
 export class Problem extends ElementWithContextMenu<typeof MarkerLocators> {
     /**
      * @private

--- a/src/pageobjects/bottomBar/Views.ts
+++ b/src/pageobjects/bottomBar/Views.ts
@@ -3,7 +3,7 @@ import clipboard from 'clipboardy'
 import { Workbench, BottomBarPanel, ContentAssist } from '../..'
 import { TextView, ChannelView } from './AbstractViews'
 import {
-    ElementWithContextMenu, PluginDecorator, IPluginDecorator, VSCodeLocatorMap
+    ElementWithContextMenu, PageDecorator, IPageDecorator, VSCodeLocatorMap
 } from '../utils'
 import {
     OutputView as OutputViewLocators,
@@ -11,7 +11,7 @@ import {
     TerminalView as TerminalViewLocators
 } from '../../locators/1.61.0'
 
-export interface OutputView extends IPluginDecorator<typeof OutputViewLocators> {}
+export interface OutputView extends IPageDecorator<typeof OutputViewLocators> {}
 /**
  * Output view of the bottom panel
  *
@@ -36,7 +36,7 @@ export interface OutputView extends IPluginDecorator<typeof OutputViewLocators> 
  *
  * @category BottomBar
  */
-@PluginDecorator(OutputViewLocators)
+@PageDecorator(OutputViewLocators)
 export class OutputView extends TextView<typeof OutputViewLocators> {
     /**
      * @private
@@ -53,14 +53,14 @@ export class OutputView extends TextView<typeof OutputViewLocators> {
     }
 }
 
-export interface DebugConsoleView extends IPluginDecorator<typeof DebugConsoleViewLocators> {}
+export interface DebugConsoleView extends IPageDecorator<typeof DebugConsoleViewLocators> {}
 /**
  * Debug Console view on the bottom panel
  * Most functionality will only be available when a debug session is running
  *
  * @category BottomBar
  */
-@PluginDecorator(DebugConsoleViewLocators)
+@PageDecorator(DebugConsoleViewLocators)
 export class DebugConsoleView extends ElementWithContextMenu<typeof DebugConsoleViewLocators> {
     /**
      * @private
@@ -127,13 +127,13 @@ export class DebugConsoleView extends ElementWithContextMenu<typeof DebugConsole
     }
 }
 
-export interface TerminalView extends IPluginDecorator<typeof TerminalViewLocators> {}
+export interface TerminalView extends IPageDecorator<typeof TerminalViewLocators> {}
 /**
  * Terminal view on the bottom panel
  *
  * @category BottomBar
  */
-@PluginDecorator(TerminalViewLocators)
+@PageDecorator(TerminalViewLocators)
 export class TerminalView extends ChannelView<typeof TerminalViewLocators> {
     /**
      * @private

--- a/src/pageobjects/dialog/ModalDialog.ts
+++ b/src/pageobjects/dialog/ModalDialog.ts
@@ -1,13 +1,13 @@
-import { PluginDecorator, IPluginDecorator, BasePage } from '../utils'
+import { PageDecorator, IPageDecorator, BasePage } from '../utils'
 import { Dialog as DialogLocators } from '../../locators/1.61.0'
 
-export interface ModalDialog extends IPluginDecorator<typeof DialogLocators> {}
+export interface ModalDialog extends IPageDecorator<typeof DialogLocators> {}
 /**
  * Page Object for Custom Style Modal Dialogs (non-native)
  *
  * @category Dialog
  */
-@PluginDecorator(DialogLocators)
+@PageDecorator(DialogLocators)
 export class ModalDialog extends BasePage<typeof DialogLocators> {
     /**
      * @private

--- a/src/pageobjects/editor/ContentAssist.ts
+++ b/src/pageobjects/editor/ContentAssist.ts
@@ -3,16 +3,16 @@ import { ChainablePromiseElement } from 'webdriverio'
 import {
     TextEditor, Menu, MenuItem, DebugConsoleView
 } from '..'
-import { PluginDecorator, IPluginDecorator, VSCodeLocatorMap } from '../utils'
+import { PageDecorator, IPageDecorator, VSCodeLocatorMap } from '../utils'
 import { ContentAssist as ContentAssistLocators } from '../../locators/1.61.0'
 
-export interface ContentAssist extends IPluginDecorator<typeof ContentAssistLocators> {}
+export interface ContentAssist extends IPageDecorator<typeof ContentAssistLocators> {}
 /**
  * Page object representing the content assistant
  *
  * @category Editor
  */
-@PluginDecorator(ContentAssistLocators)
+@PageDecorator(ContentAssistLocators)
 export class ContentAssist extends Menu<typeof ContentAssistLocators> {
     /**
      * @private
@@ -98,13 +98,13 @@ export class ContentAssist extends Menu<typeof ContentAssistLocators> {
     }
 }
 
-export interface ContentAssistItem extends IPluginDecorator<typeof ContentAssistLocators> {}
+export interface ContentAssistItem extends IPageDecorator<typeof ContentAssistLocators> {}
 /**
  * Page object for a content assist item
  *
  * @category Editor
  */
-@PluginDecorator(ContentAssistLocators)
+@PageDecorator(ContentAssistLocators)
 export class ContentAssistItem extends MenuItem<typeof ContentAssistLocators> {
     /**
      * @private

--- a/src/pageobjects/editor/CustomEditor.ts
+++ b/src/pageobjects/editor/CustomEditor.ts
@@ -1,15 +1,15 @@
 import { Editor, InputBox, WebView } from '..'
-import { PluginDecorator, IPluginDecorator } from '../utils'
+import { PageDecorator, IPageDecorator } from '../utils'
 import { Editor as EditorLocators } from '../../locators/1.61.0'
 import { CMD_KEY } from '../../constants'
 
-export interface CustomEditor extends IPluginDecorator<typeof EditorLocators> {}
+export interface CustomEditor extends IPageDecorator<typeof EditorLocators> {}
 /**
  * Page object for custom editors
  *
  * @category Editor
  */
-@PluginDecorator(EditorLocators)
+@PageDecorator(EditorLocators)
 export class CustomEditor extends Editor<typeof EditorLocators> {
     /**
      * @private

--- a/src/pageobjects/editor/DiffEditor.ts
+++ b/src/pageobjects/editor/DiffEditor.ts
@@ -1,16 +1,16 @@
 import { Editor, EditorLocators } from './Editor'
 import { TextEditor } from './TextEditor'
 import { EditorView } from './EditorView'
-import { PluginDecorator, IPluginDecorator } from '../utils'
+import { PageDecorator, IPageDecorator } from '../utils'
 import { DiffEditor as DiffEditorLocators } from '../../locators/1.61.0'
 
-export interface DiffEditor extends IPluginDecorator<EditorLocators> {}
+export interface DiffEditor extends IPageDecorator<EditorLocators> {}
 /**
  * Page object representing a diff editor
  *
  * @category Editor
  */
-@PluginDecorator(DiffEditorLocators)
+@PageDecorator(DiffEditorLocators)
 export class DiffEditor extends Editor<EditorLocators> {
     /**
      * @private

--- a/src/pageobjects/editor/EditorView.ts
+++ b/src/pageobjects/editor/EditorView.ts
@@ -4,20 +4,20 @@ import {
     TextEditor, DiffEditor, SettingsEditor, WebView
 } from '..'
 import {
-    PluginDecorator, IPluginDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
 } from '../utils'
 import {
     EditorView as EditorViewLocators,
     Editor as EditorLocatorsObj
 } from '../../locators/1.61.0'
 
-export interface EditorView extends IPluginDecorator<typeof EditorViewLocators> {}
+export interface EditorView extends IPageDecorator<typeof EditorViewLocators> {}
 /**
  * View handling the open editors
  *
  * @category Editor
  */
-@PluginDecorator(EditorViewLocators)
+@PageDecorator(EditorViewLocators)
 export class EditorView extends BasePage<typeof EditorViewLocators> {
     /**
      * @private
@@ -180,13 +180,13 @@ export class EditorView extends BasePage<typeof EditorViewLocators> {
     }
 }
 
-export interface EditorGroup extends IPluginDecorator<typeof EditorViewLocators> {}
+export interface EditorGroup extends IPageDecorator<typeof EditorViewLocators> {}
 /**
  * Page object representing an editor group
  *
  * @category Editor
  */
-@PluginDecorator(EditorViewLocators)
+@PageDecorator(EditorViewLocators)
 export class EditorGroup extends BasePage<typeof EditorViewLocators> {
     /**
      * @private
@@ -361,13 +361,13 @@ export class EditorGroup extends BasePage<typeof EditorViewLocators> {
     }
 }
 
-export interface EditorTab extends IPluginDecorator<typeof EditorLocatorsObj> {}
+export interface EditorTab extends IPageDecorator<typeof EditorLocatorsObj> {}
 /**
  * Page object for editor view tab
  *
  * @category Editor
  */
-@PluginDecorator(EditorLocatorsObj)
+@PageDecorator(EditorLocatorsObj)
 export class EditorTab extends ElementWithContextMenu<typeof EditorLocatorsObj> {
     /**
      * @private

--- a/src/pageobjects/editor/SettingsEditor.ts
+++ b/src/pageobjects/editor/SettingsEditor.ts
@@ -3,17 +3,17 @@ import { ContextMenu } from '../menu/ContextMenu'
 import { EditorView, EditorGroup } from '..'
 
 import {
-    PluginDecorator, IPluginDecorator, BasePage, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, VSCodeLocatorMap
 } from '../utils'
 import { SettingsEditor as SettingsEditorLocators } from '../../locators/1.61.0'
 
-export interface SettingsEditor extends IPluginDecorator<EditorLocators> {}
+export interface SettingsEditor extends IPageDecorator<EditorLocators> {}
 /**
  * Page object representing the internal VSCode settings editor
  *
  * @category Editor
  */
-@PluginDecorator(SettingsEditorLocators)
+@PageDecorator(SettingsEditorLocators)
 export class SettingsEditor extends Editor<EditorLocators> {
     /**
      * @private
@@ -122,7 +122,7 @@ export class SettingsEditor extends Editor<EditorLocators> {
     }
 }
 
-export interface Setting extends IPluginDecorator<typeof SettingsEditorLocators> {}
+export interface Setting extends IPageDecorator<typeof SettingsEditorLocators> {}
 /**
  * Abstract item representing a Setting with title, description and
  * an input element (combo/textbox/checkbox/link)
@@ -186,7 +186,7 @@ export abstract class Setting extends BasePage<typeof SettingsEditorLocators> {
  *
  * @category Editor
  */
-@PluginDecorator(SettingsEditorLocators)
+@PageDecorator(SettingsEditorLocators)
 export class ComboSetting extends Setting {
     /**
      * @private
@@ -251,13 +251,13 @@ export class ComboSetting extends Setting {
     }
 }
 
-export interface TextSetting extends IPluginDecorator<typeof SettingsEditorLocators> {}
+export interface TextSetting extends IPageDecorator<typeof SettingsEditorLocators> {}
 /**
  * Setting with a text box input
  *
  * @category Editor
  */
-@PluginDecorator(SettingsEditorLocators)
+@PageDecorator(SettingsEditorLocators)
 export class TextSetting extends Setting {
     /**
      * @private
@@ -274,13 +274,13 @@ export class TextSetting extends Setting {
     }
 }
 
-export interface TextSetting extends IPluginDecorator<typeof SettingsEditorLocators> {}
+export interface TextSetting extends IPageDecorator<typeof SettingsEditorLocators> {}
 /**
  * Setting with a checkbox
  *
  * @category Editor
  */
-@PluginDecorator(SettingsEditorLocators)
+@PageDecorator(SettingsEditorLocators)
 export class CheckboxSetting extends Setting {
     /**
      * @private
@@ -302,13 +302,13 @@ export class CheckboxSetting extends Setting {
     }
 }
 
-export interface LinkSetting extends IPluginDecorator<typeof SettingsEditorLocators> {}
+export interface LinkSetting extends IPageDecorator<typeof SettingsEditorLocators> {}
 /**
  * Setting with no value, with a link to settings.json instead
  *
  * @category Editor
  */
-@PluginDecorator(SettingsEditorLocators)
+@PageDecorator(SettingsEditorLocators)
 export class LinkSetting extends Setting {
     /**
      * @private

--- a/src/pageobjects/editor/TextEditor.ts
+++ b/src/pageobjects/editor/TextEditor.ts
@@ -7,7 +7,7 @@ import { StatusBar } from '../statusBar/StatusBar'
 import { Editor, EditorLocators } from './Editor'
 
 import {
-    PluginDecorator, IPluginDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
 } from '../utils'
 import {
     TextEditor as TextEditorLocators,
@@ -15,13 +15,13 @@ import {
 } from '../../locators/1.61.0'
 import { CMD_KEY } from '../../constants'
 
-export interface TextEditor extends IPluginDecorator<EditorLocators> {}
+export interface TextEditor extends IPageDecorator<EditorLocators> {}
 /**
  * Page object representing the active text editor
  *
  * @category Editor
  */
-@PluginDecorator(TextEditorLocators)
+@PageDecorator(TextEditorLocators)
 export class TextEditor extends Editor<EditorLocators> {
     /**
      * @private
@@ -443,13 +443,13 @@ export class TextEditor extends Editor<EditorLocators> {
     }
 }
 
-interface Selection extends IPluginDecorator<typeof TextEditorLocators> {}
+interface Selection extends IPageDecorator<typeof TextEditorLocators> {}
 /**
  * Text selection block
  *
  * @category Editor
  */
-@PluginDecorator(TextEditorLocators)
+@PageDecorator(TextEditorLocators)
 class Selection extends ElementWithContextMenu<typeof TextEditorLocators> {
     /**
      * @private
@@ -476,13 +476,13 @@ class Selection extends ElementWithContextMenu<typeof TextEditorLocators> {
     }
 }
 
-export interface CodeLens extends IPluginDecorator<typeof TextEditorLocators> {}
+export interface CodeLens extends IPageDecorator<typeof TextEditorLocators> {}
 /**
  * Page object for Code Lens inside a text editor
  *
  * @category Editor
  */
-@PluginDecorator(TextEditorLocators)
+@PageDecorator(TextEditorLocators)
 export class CodeLens extends BasePage<typeof TextEditorLocators> {
     /**
      * @private
@@ -516,13 +516,13 @@ export class CodeLens extends BasePage<typeof TextEditorLocators> {
     }
 }
 
-export interface FindWidget extends IPluginDecorator<typeof FindWidgetLocators> {}
+export interface FindWidget extends IPageDecorator<typeof FindWidgetLocators> {}
 /**
  * Text Editor's Find Widget
  *
  * @category Editor
  */
-@PluginDecorator(FindWidgetLocators)
+@PageDecorator(FindWidgetLocators)
 export class FindWidget extends BasePage<typeof FindWidgetLocators> {
     /**
      * @private

--- a/src/pageobjects/editor/WebView.ts
+++ b/src/pageobjects/editor/WebView.ts
@@ -1,16 +1,16 @@
 import { Editor, EditorLocators } from './Editor'
-import { PluginDecorator, IPluginDecorator } from '../utils'
+import { PageDecorator, IPageDecorator } from '../utils'
 import { WebView as WebViewLocators } from '../../locators/1.61.0'
 
 let handle: string | undefined
 
-export interface WebView extends IPluginDecorator<EditorLocators> {}
+export interface WebView extends IPageDecorator<EditorLocators> {}
 /**
  * Page object representing an open editor containing a web view
  *
  * @category Editor
  */
-@PluginDecorator(WebViewLocators)
+@PageDecorator(WebViewLocators)
 export class WebView extends Editor<EditorLocators> {
     /**
      * @private

--- a/src/pageobjects/menu/ContextMenu.ts
+++ b/src/pageobjects/menu/ContextMenu.ts
@@ -1,16 +1,16 @@
 import type { ChainablePromiseElement } from 'webdriverio'
 
 import { Menu, MenuItem } from '..'
-import { PluginDecorator, IPluginDecorator, VSCodeLocatorMap } from '../utils'
+import { PageDecorator, IPageDecorator, VSCodeLocatorMap } from '../utils'
 import { ContextMenu as ContextMenuLocators } from '../../locators/1.61.0'
 
-export interface ContextMenu extends IPluginDecorator<typeof ContextMenuLocators> {}
+export interface ContextMenu extends IPageDecorator<typeof ContextMenuLocators> {}
 /**
  * Object representing a context menu
  *
  * @category Menu
  */
-@PluginDecorator(ContextMenuLocators)
+@PageDecorator(ContextMenuLocators)
 export class ContextMenu extends Menu<typeof ContextMenuLocators> {
     /**
      * @private
@@ -89,13 +89,13 @@ export class ContextMenu extends Menu<typeof ContextMenuLocators> {
     }
 }
 
-export interface ContextMenuItem extends IPluginDecorator<typeof ContextMenuLocators> {}
+export interface ContextMenuItem extends IPageDecorator<typeof ContextMenuLocators> {}
 /**
  * Object representing an item of a context menu
  *
  * @category Menu
  */
-@PluginDecorator(ContextMenuLocators)
+@PageDecorator(ContextMenuLocators)
 export class ContextMenuItem extends MenuItem<typeof ContextMenuLocators> {
     /**
      * @private

--- a/src/pageobjects/menu/TitleBar.ts
+++ b/src/pageobjects/menu/TitleBar.ts
@@ -1,16 +1,16 @@
-import { PluginDecorator, IPluginDecorator, VSCodeLocatorMap } from '../utils'
+import { PageDecorator, IPageDecorator, VSCodeLocatorMap } from '../utils'
 import { WindowControls, ContextMenu } from '..'
 import { Menu } from './Menu'
 import { MenuItem } from './MenuItem'
 import { TitleBar as TitleBarLocators } from '../../locators/1.61.0'
 
-export interface TitleBar extends IPluginDecorator<typeof TitleBarLocators> {}
+export interface TitleBar extends IPageDecorator<typeof TitleBarLocators> {}
 /**
  * Page object representing the custom VSCode title bar
  *
  * @category Menu
  */
-@PluginDecorator(TitleBarLocators)
+@PageDecorator(TitleBarLocators)
 export class TitleBar extends Menu<typeof TitleBarLocators> {
     /**
      * @private
@@ -77,13 +77,13 @@ export class TitleBar extends Menu<typeof TitleBarLocators> {
     }
 }
 
-export interface TitleBarItem extends IPluginDecorator<typeof TitleBarLocators> {}
+export interface TitleBarItem extends IPageDecorator<typeof TitleBarLocators> {}
 /**
  * Page object representing an item of the custom VSCode title bar
  *
  * @category Menu
  */
-@PluginDecorator(TitleBarLocators)
+@PageDecorator(TitleBarLocators)
 export class TitleBarItem extends MenuItem<typeof TitleBarLocators> {
     /**
      * @private

--- a/src/pageobjects/menu/WindowControls.ts
+++ b/src/pageobjects/menu/WindowControls.ts
@@ -1,18 +1,18 @@
 import type { ChainablePromiseElement } from 'webdriverio'
 
 import {
-    PluginDecorator, IPluginDecorator, BasePage, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, VSCodeLocatorMap
 } from '../utils'
 import { TitleBar } from '../..'
 import { WindowControls as WindowControlsLocators } from '../../locators/1.61.0'
 
-export interface WindowControls extends IPluginDecorator<typeof WindowControlsLocators> {}
+export interface WindowControls extends IPageDecorator<typeof WindowControlsLocators> {}
 /**
  * Page object for the windows controls part of the title bar
  *
  * @category Menu
  */
-@PluginDecorator(WindowControlsLocators)
+@PageDecorator(WindowControlsLocators)
 export class WindowControls extends BasePage<typeof WindowControlsLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/SideBarView.ts
+++ b/src/pageobjects/sidebar/SideBarView.ts
@@ -1,16 +1,16 @@
 import { ViewContent, ViewTitlePart } from '..'
 import {
-    PluginDecorator, IPluginDecorator, BasePage, LocatorComponents
+    PageDecorator, IPageDecorator, BasePage, LocatorComponents
 } from '../utils'
 import { SideBarView as SideBarViewLocators } from '../../locators/1.61.0'
 
-export interface SideBarView<T> extends IPluginDecorator<typeof SideBarViewLocators> { }
+export interface SideBarView<T> extends IPageDecorator<typeof SideBarViewLocators> { }
 /**
  * Page object for the side bar view
  *
  * @category Sidebar
  */
-@PluginDecorator(SideBarViewLocators)
+@PageDecorator(SideBarViewLocators)
 export class SideBarView<T> extends BasePage<T> {
     /**
      * @private

--- a/src/pageobjects/sidebar/ViewContent.ts
+++ b/src/pageobjects/sidebar/ViewContent.ts
@@ -3,17 +3,17 @@ import { DefaultTreeSection } from './tree/default/DefaultTreeSection'
 import { CustomTreeSection } from './tree/custom/CustomTreeSection'
 import { ExtensionsViewSection } from './extensions/ExtensionsViewSection'
 import {
-    PluginDecorator, IPluginDecorator, BasePage, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, VSCodeLocatorMap
 } from '../utils'
 import { ViewContent as ViewContentLocators } from '../../locators/1.61.0'
 
-export interface ViewContent extends IPluginDecorator<typeof ViewContentLocators> { }
+export interface ViewContent extends IPageDecorator<typeof ViewContentLocators> { }
 /**
  * Page object representing the view container of a side bar view
  *
  * @category Sidebar
  */
-@PluginDecorator(ViewContentLocators)
+@PageDecorator(ViewContentLocators)
 export class ViewContent extends BasePage<typeof ViewContentLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/ViewItem.ts
+++ b/src/pageobjects/sidebar/ViewItem.ts
@@ -1,5 +1,5 @@
 import {
-    IPluginDecorator, BasePage, ElementWithContextMenu, PluginDecorator, VSCodeLocatorMap
+    IPageDecorator, BasePage, ElementWithContextMenu, PageDecorator, VSCodeLocatorMap
 } from '../utils'
 import {
     ViewSection as ViewSectionLocators,
@@ -21,7 +21,7 @@ export type ViewItemLocators = (
     typeof ExtensionsViewItemLocators
 )
 
-export interface ViewItem extends IPluginDecorator<ViewItemLocators> { }
+export interface ViewItem extends IPageDecorator<ViewItemLocators> { }
 /**
  * Arbitrary item in the side bar view
  *
@@ -38,7 +38,7 @@ export abstract class ViewItem extends ElementWithContextMenu<ViewItemLocators> 
     }
 }
 
-export interface TreeItem extends IPluginDecorator<ViewItemLocators> { }
+export interface TreeItem extends IPageDecorator<ViewItemLocators> { }
 /**
  * TreeItem abstract class
  *
@@ -197,13 +197,13 @@ export abstract class TreeItem extends ViewItem {
     }
 }
 
-export interface ViewItemAction extends IPluginDecorator<typeof ViewSectionLocators> { }
+export interface ViewItemAction extends IPageDecorator<typeof ViewSectionLocators> { }
 /**
  * Action button bound to a view item
  *
  * @category Sidebar
  */
-@PluginDecorator(ViewSectionLocators)
+@PageDecorator(ViewSectionLocators)
 export class ViewItemAction extends BasePage<typeof ViewSectionLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/ViewSection.ts
+++ b/src/pageobjects/sidebar/ViewSection.ts
@@ -4,7 +4,7 @@ import {
     ContextMenu, ViewContent, ViewItem, WelcomeContentSection
 } from '..'
 import {
-    PluginDecorator, IPluginDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
 } from '../utils'
 import {
     ViewSection as ViewSectionLocators,
@@ -23,7 +23,7 @@ export type AllViewSectionLocators = (
     typeof DefaultTreeSectionLocators
 )
 
-export interface ViewSection extends IPluginDecorator<AllViewSectionLocators> { }
+export interface ViewSection extends IPageDecorator<AllViewSectionLocators> { }
 /**
  * Page object representing a collapsible content section of the side bar view
  *
@@ -216,13 +216,13 @@ export abstract class ViewSection extends BasePage<AllViewSectionLocators> {
     }
 }
 
-export interface ViewPanelAction extends IPluginDecorator<typeof ViewSectionLocators> { }
+export interface ViewPanelAction extends IPageDecorator<typeof ViewSectionLocators> { }
 /**
  * Action button on the header of a view section
  *
  * @category Sidebar
  */
-@PluginDecorator(ViewSectionLocators)
+@PageDecorator(ViewSectionLocators)
 export class ViewPanelAction extends BasePage<typeof ViewSectionLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/ViewTitlePart.ts
+++ b/src/pageobjects/sidebar/ViewTitlePart.ts
@@ -1,16 +1,16 @@
 import {
-    ElementWithContextMenu, PluginDecorator, IPluginDecorator, BasePage, VSCodeLocatorMap
+    ElementWithContextMenu, PageDecorator, IPageDecorator, BasePage, VSCodeLocatorMap
 } from '../utils'
 import { SideBarView } from '..'
 import { ViewTitlePart as ViewTitlePartLocators } from '../../locators/1.61.0'
 
-export interface ViewTitlePart extends IPluginDecorator<typeof ViewTitlePartLocators> { }
+export interface ViewTitlePart extends IPageDecorator<typeof ViewTitlePartLocators> { }
 /**
  * Page object representing the top (title) part of a side bar view
  *
  * @category Sidebar
  */
-@PluginDecorator(ViewTitlePartLocators)
+@PageDecorator(ViewTitlePartLocators)
 export class ViewTitlePart extends ElementWithContextMenu<typeof ViewTitlePartLocators> {
     /**
      * @private
@@ -56,13 +56,13 @@ export class ViewTitlePart extends ElementWithContextMenu<typeof ViewTitlePartLo
     }
 }
 
-export interface ViewTitlePart extends IPluginDecorator<typeof ViewTitlePartLocators> { }
+export interface ViewTitlePart extends IPageDecorator<typeof ViewTitlePartLocators> { }
 /**
  * Page object representing a button inside the view title part
  *
  * @category Sidebar
  */
-@PluginDecorator(ViewTitlePartLocators)
+@PageDecorator(ViewTitlePartLocators)
 export class TitleActionButton extends BasePage<typeof ViewTitlePartLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/WelcomeContent.ts
+++ b/src/pageobjects/sidebar/WelcomeContent.ts
@@ -2,11 +2,11 @@ import { ChainablePromiseElement } from 'webdriverio'
 
 import { ViewSection } from '..'
 import {
-    BasePage, PluginDecorator, IPluginDecorator, VSCodeLocatorMap
+    BasePage, PageDecorator, IPageDecorator, VSCodeLocatorMap
 } from '../utils'
 import { WelcomeContent as WelcomeContentLocators } from '../../locators/1.61.0'
 
-export interface WelcomeContentButton extends IPluginDecorator<typeof WelcomeContentLocators> {}
+export interface WelcomeContentButton extends IPageDecorator<typeof WelcomeContentLocators> {}
 /**
  * A button that appears in the welcome content and can be clicked to execute a command.
  *
@@ -14,7 +14,7 @@ export interface WelcomeContentButton extends IPluginDecorator<typeof WelcomeCon
  *
  * @category Sidebar
  */
-@PluginDecorator(WelcomeContentLocators)
+@PageDecorator(WelcomeContentLocators)
 export class WelcomeContentButton extends BasePage<typeof WelcomeContentLocators> {
     /**
      * @private
@@ -39,7 +39,7 @@ export class WelcomeContentButton extends BasePage<typeof WelcomeContentLocators
     }
 }
 
-export interface WelcomeContentSection extends IPluginDecorator<typeof WelcomeContentLocators> {}
+export interface WelcomeContentSection extends IPageDecorator<typeof WelcomeContentLocators> {}
 /**
  * A section in an empty custom view, see:
  * https://code.visualstudio.com/api/extension-guides/tree-view#welcome-content
@@ -54,7 +54,7 @@ export interface WelcomeContentSection extends IPluginDecorator<typeof WelcomeCo
  *
  * @category Sidebar
  */
-@PluginDecorator(WelcomeContentLocators)
+@PageDecorator(WelcomeContentLocators)
 export class WelcomeContentSection extends BasePage<typeof WelcomeContentLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/debug/DebugView.ts
+++ b/src/pageobjects/sidebar/debug/DebugView.ts
@@ -1,14 +1,14 @@
 import { SideBarView } from '../SideBarView'
-import { PluginDecorator, IPluginDecorator } from '../../utils'
+import { PageDecorator, IPageDecorator } from '../../utils'
 import { DebugView as DebugViewLocators } from '../../../locators/1.61.0'
 
-export interface DebugView extends IPluginDecorator<typeof DebugViewLocators> { }
+export interface DebugView extends IPageDecorator<typeof DebugViewLocators> { }
 /**
  * Page object representing the Run/Debug view in the side bar
  *
  * @category Sidebar
  */
-@PluginDecorator(DebugViewLocators)
+@PageDecorator(DebugViewLocators)
 export class DebugView extends SideBarView<typeof DebugViewLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/extensions/ExtensionsViewItem.ts
+++ b/src/pageobjects/sidebar/extensions/ExtensionsViewItem.ts
@@ -4,16 +4,16 @@ import { ViewItem, ViewItemLocators } from '../ViewItem'
 import { ContextMenu } from '../../menu/ContextMenu'
 import { ExtensionsViewSection } from './ExtensionsViewSection'
 
-import { PluginDecorator, IPluginDecorator, VSCodeLocatorMap } from '../../utils'
+import { PageDecorator, IPageDecorator, VSCodeLocatorMap } from '../../utils'
 import { ExtensionsViewItem as ExtensionsViewItemLocators } from '../../../locators/1.61.0'
 
-export interface ExtensionsViewItem extends IPluginDecorator<ViewItemLocators> { }
+export interface ExtensionsViewItem extends IPageDecorator<ViewItemLocators> { }
 /**
  * Page object representing an extension in the extensions view
  *
  * @category Sidebar
  */
-@PluginDecorator(ExtensionsViewItemLocators)
+@PageDecorator(ExtensionsViewItemLocators)
 export class ExtensionsViewItem extends ViewItem {
     /**
      * @private

--- a/src/pageobjects/sidebar/extensions/ExtensionsViewSection.ts
+++ b/src/pageobjects/sidebar/extensions/ExtensionsViewSection.ts
@@ -1,6 +1,6 @@
 import { ViewSection } from '../ViewSection'
 import { ExtensionsViewItem, AllViewSectionLocators } from '../..'
-import { PluginDecorator, IPluginDecorator } from '../../utils'
+import { PageDecorator, IPageDecorator } from '../../utils'
 import { ExtensionsViewSection as ExtensionsViewSectionLocators } from '../../../locators/1.61.0'
 import { CMD_KEY } from '../../../constants'
 
@@ -15,13 +15,13 @@ enum ExtensionCategory {
     Recommended = '@recommended'
 }
 
-export interface ExtensionsViewSection extends IPluginDecorator<AllViewSectionLocators> { }
+export interface ExtensionsViewSection extends IPageDecorator<AllViewSectionLocators> { }
 /**
  * View section containing extensions
  *
  * @category Sidebar
  */
-@PluginDecorator(ExtensionsViewSectionLocators)
+@PageDecorator(ExtensionsViewSectionLocators)
 export class ExtensionsViewSection extends ViewSection {
     /**
      * @private

--- a/src/pageobjects/sidebar/scm/NewScmView.ts
+++ b/src/pageobjects/sidebar/scm/NewScmView.ts
@@ -3,18 +3,18 @@ import {
 } from './ScmView'
 import { ContextMenu } from '../..'
 import {
-    PluginDecorator, IPluginDecorator, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, ElementWithContextMenu, VSCodeLocatorMap
 } from '../../utils'
 import { ScmView as ScmViewLocators } from '../../../locators/1.61.0'
 import { CMD_KEY } from '../../../constants'
 
-export interface NewScmView extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface NewScmView extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * New SCM view for code 1.47 onwards
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class NewScmView extends ScmView {
     async getProviders (): Promise<ScmProvider[]> {
         const inputs = await this.inputField$$
@@ -37,13 +37,13 @@ export class NewScmView extends ScmView {
     }
 }
 
-export interface SingleScmProvider extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface SingleScmProvider extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * Implementation for a single SCM provider
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class SingleScmProvider extends ScmProvider {
     /**
      * There is no title available for a single provider
@@ -105,13 +105,13 @@ export class SingleScmProvider extends ScmProvider {
     }
 }
 
-export interface MultiScmProvider extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface MultiScmProvider extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * Implementation of an SCM provider when multiple providers are available
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class MultiScmProvider extends ScmProvider {
     async takeAction (title: string): Promise<boolean> {
         const actions = await this.action$$
@@ -191,13 +191,13 @@ export class MultiScmProvider extends ScmProvider {
     }
 }
 
-interface MultiMoreAction extends IPluginDecorator<typeof ScmViewLocators> { }
+interface MultiMoreAction extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * Multi More Action
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 class MultiMoreAction extends ElementWithContextMenu<typeof ScmViewLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/scm/ScmView.ts
+++ b/src/pageobjects/sidebar/scm/ScmView.ts
@@ -3,18 +3,18 @@ import type { ChainablePromiseElement } from 'webdriverio'
 import { SideBarView } from '../SideBarView'
 import { ContextMenu } from '../..'
 import {
-    ElementWithContextMenu, VSCodeLocatorMap, PluginDecorator, IPluginDecorator, BasePage
+    ElementWithContextMenu, VSCodeLocatorMap, PageDecorator, IPageDecorator, BasePage
 } from '../../utils'
 import { ScmView as ScmViewLocators } from '../../../locators/1.61.0'
 import { CMD_KEY } from '../../../constants'
 
-export interface ScmView extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface ScmView extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * Page object representing the Source Control view
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class ScmView extends SideBarView<typeof ScmViewLocators> {
     /**
      * @private
@@ -62,14 +62,14 @@ export class ScmView extends SideBarView<typeof ScmViewLocators> {
     }
 }
 
-export interface ScmProvider extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface ScmProvider extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * Page object representing a repository in the source control view
  * Maps roughly to a view section of the source control view
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class ScmProvider extends BasePage<typeof ScmViewLocators> {
     /**
      * @private
@@ -196,13 +196,13 @@ export class ScmProvider extends BasePage<typeof ScmViewLocators> {
     }
 }
 
-export interface ScmChange extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface ScmChange extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * Page object representing a SCM change tree item
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class ScmChange extends ElementWithContextMenu<typeof ScmViewLocators> {
     /**
      * @private
@@ -293,13 +293,13 @@ export class ScmChange extends ElementWithContextMenu<typeof ScmViewLocators> {
     }
 }
 
-export interface MoreAction extends IPluginDecorator<typeof ScmViewLocators> { }
+export interface MoreAction extends IPageDecorator<typeof ScmViewLocators> { }
 /**
  * More Action
  *
  * @category Sidebar
  */
-@PluginDecorator(ScmViewLocators)
+@PageDecorator(ScmViewLocators)
 export class MoreAction extends ElementWithContextMenu<typeof ScmViewLocators> {
     /**
      * @private

--- a/src/pageobjects/sidebar/tree/custom/CustomTreeItem.ts
+++ b/src/pageobjects/sidebar/tree/custom/CustomTreeItem.ts
@@ -2,16 +2,16 @@ import type { ChainablePromiseElement } from 'webdriverio'
 
 import { TreeSection } from '../TreeSection'
 import { TreeItem, ViewItemLocators } from '../../ViewItem'
-import { PluginDecorator, IPluginDecorator, VSCodeLocatorMap } from '../../../utils'
+import { PageDecorator, IPageDecorator, VSCodeLocatorMap } from '../../../utils'
 import { CustomTreeItem as CustomTreeItemLocator } from '../../../../locators/1.61.0'
 
-export interface CustomTreeItem extends IPluginDecorator<ViewItemLocators> { }
+export interface CustomTreeItem extends IPageDecorator<ViewItemLocators> { }
 /**
  * View item in a custom-made content section (e.g. an extension tree view)
  *
  * @category Sidebar
  */
-@PluginDecorator(CustomTreeItemLocator)
+@PageDecorator(CustomTreeItemLocator)
 export class CustomTreeItem extends TreeItem {
     /**
      * @private

--- a/src/pageobjects/sidebar/tree/custom/CustomTreeSection.ts
+++ b/src/pageobjects/sidebar/tree/custom/CustomTreeSection.ts
@@ -3,16 +3,16 @@ import { TreeItem } from '../../ViewItem'
 import { CustomTreeItem } from './CustomTreeItem'
 import { AllViewSectionLocators } from '../../ViewSection'
 
-import { PluginDecorator, IPluginDecorator } from '../../../utils'
+import { PageDecorator, IPageDecorator } from '../../../utils'
 import { CustomTreeSection as CustomTreeSectionLocator } from '../../../../locators/1.61.0'
 
-export interface CustomTreeSection extends IPluginDecorator<AllViewSectionLocators> { }
+export interface CustomTreeSection extends IPageDecorator<AllViewSectionLocators> { }
 /**
  * Custom tree view, e.g. contributed by an extension
  *
  * @category Sidebar
  */
-@PluginDecorator(CustomTreeSectionLocator)
+@PageDecorator(CustomTreeSectionLocator)
 export class CustomTreeSection extends TreeSection {
     /**
      * @private

--- a/src/pageobjects/sidebar/tree/default/DefaultTreeItem.ts
+++ b/src/pageobjects/sidebar/tree/default/DefaultTreeItem.ts
@@ -2,16 +2,16 @@ import { ChainablePromiseElement } from 'webdriverio'
 
 import { TreeItem, ViewItemLocators } from '../../ViewItem'
 import { TreeSection } from '../TreeSection'
-import { PluginDecorator, IPluginDecorator, VSCodeLocatorMap } from '../../../utils'
+import { PageDecorator, IPageDecorator, VSCodeLocatorMap } from '../../../utils'
 import { DefaultTreeItem as DefaultTreeItemLocators } from '../../../../locators/1.61.0'
 
-export interface DefaultTreeItem extends IPluginDecorator<ViewItemLocators> { }
+export interface DefaultTreeItem extends IPageDecorator<ViewItemLocators> { }
 /**
  * Default tree item base on the items in explorer view
  *
  * @category Sidebar
  */
-@PluginDecorator(DefaultTreeItemLocators)
+@PageDecorator(DefaultTreeItemLocators)
 export class DefaultTreeItem extends TreeItem {
     /**
      * @private

--- a/src/pageobjects/sidebar/tree/default/DefaultTreeSection.ts
+++ b/src/pageobjects/sidebar/tree/default/DefaultTreeSection.ts
@@ -2,16 +2,16 @@ import { TreeSection } from '../TreeSection'
 import { TreeItem, AllViewSectionLocators } from '../../..'
 import { DefaultTreeItem } from './DefaultTreeItem'
 
-import { PluginDecorator, IPluginDecorator } from '../../../utils'
+import { PageDecorator, IPageDecorator } from '../../../utils'
 import { DefaultTreeSection as DefaultTreeSectionLocators } from '../../../../locators/1.61.0'
 
-export interface DefaultTreeSection extends IPluginDecorator<AllViewSectionLocators> { }
+export interface DefaultTreeSection extends IPageDecorator<AllViewSectionLocators> { }
 /**
  * Default view section
  *
  * @category Sidebar
  */
-@PluginDecorator(DefaultTreeSectionLocators)
+@PageDecorator(DefaultTreeSectionLocators)
 export class DefaultTreeSection extends TreeSection {
     /**
      * @private

--- a/src/pageobjects/statusBar/StatusBar.ts
+++ b/src/pageobjects/statusBar/StatusBar.ts
@@ -1,14 +1,14 @@
-import { PluginDecorator, IPluginDecorator, BasePage } from '../utils'
+import { PageDecorator, IPageDecorator, BasePage } from '../utils'
 import { StatusBar as StatusBarLocators } from '../../locators/1.61.0'
 import { NotificationsCenter } from '..'
 
-export interface StatusBar extends IPluginDecorator<typeof StatusBarLocators> {}
+export interface StatusBar extends IPageDecorator<typeof StatusBarLocators> {}
 /**
  * Page object for the status bar at the bottom
  *
  * @category Statusbar
  */
-@PluginDecorator(StatusBarLocators)
+@PageDecorator(StatusBarLocators)
 export class StatusBar extends BasePage<typeof StatusBarLocators> {
     /**
      * @private

--- a/src/pageobjects/utils.ts
+++ b/src/pageobjects/utils.ts
@@ -43,12 +43,12 @@ type AllLocatorType = typeof allLocatorsTypes
 export type LocatorComponents = keyof AllLocatorType | (keyof AllLocatorType)[]
 export type Locators = Record<string | symbol, string | Function>
 export type VSCodeLocatorMap = Record<keyof AllLocatorType, Locators>
-export type IPluginDecorator<T> = (
+export type IPageDecorator<T> = (
     ClassWithLocators$<T> & ClassWithLocators$$<T> &
     ClassWithFunctionLocators$<T> & ClassWithFunctionLocators$$<T>
 )
 
-export function PluginDecorator<T extends { new(...args: any[]): any }> (locators: Locators) {
+export function PageDecorator<T extends { new(...args: any[]): any }> (locators: Locators) {
     return (ctor: T) => {
         for (const [prop, globalLocator] of Object.entries(locators)) {
             // eslint-disable-next-line @typescript-eslint/no-unsafe-call

--- a/src/pageobjects/utils.ts
+++ b/src/pageobjects/utils.ts
@@ -90,7 +90,6 @@ export abstract class BasePage<PageLocators, LocatorMap extends Record<string, L
 
     /**
      * Get the locator map of given page object
-     *
      */
     get locators () {
         if (Array.isArray(this.locatorKey)) {

--- a/src/pageobjects/workbench/DebugToolbar.ts
+++ b/src/pageobjects/workbench/DebugToolbar.ts
@@ -1,14 +1,14 @@
 import { ChainablePromiseElement } from 'webdriverio'
-import { BasePage, PluginDecorator, IPluginDecorator } from '../utils'
+import { BasePage, PageDecorator, IPageDecorator } from '../utils'
 import { DebugToolbar as DebugToolbarLocators } from '../../locators/1.61.0'
 
-export interface DebugToolbar extends IPluginDecorator<typeof DebugToolbarLocators> {}
+export interface DebugToolbar extends IPageDecorator<typeof DebugToolbarLocators> {}
 /**
  * Page object for the Debugger Toolbar
  *
  * @category Workbench
  */
-@PluginDecorator(DebugToolbarLocators)
+@PageDecorator(DebugToolbarLocators)
 export class DebugToolbar extends BasePage<typeof DebugToolbarLocators> {
     /**
      * @private

--- a/src/pageobjects/workbench/Input.ts
+++ b/src/pageobjects/workbench/Input.ts
@@ -1,6 +1,6 @@
 import clipboard from 'clipboardy'
 import {
-    IPluginDecorator, BasePage, PluginDecorator, VSCodeLocatorMap
+    IPageDecorator, BasePage, PageDecorator, VSCodeLocatorMap
 } from '../utils'
 import {
     Input as InputLocators,
@@ -10,7 +10,7 @@ import {
 import { CMD_KEY } from '../../constants'
 
 type AllInputLocators = typeof InputLocators & typeof InputBoxLocators & typeof QuickOpenBoxLocators
-export interface Input extends IPluginDecorator<AllInputLocators> {}
+export interface Input extends IPageDecorator<AllInputLocators> {}
 /**
  * Abstract page object for input fields
  *
@@ -219,13 +219,13 @@ export abstract class Input extends BasePage<AllInputLocators> {
     }
 }
 
-export interface QuickPickItem extends IPluginDecorator<typeof InputLocators> {}
+export interface QuickPickItem extends IPageDecorator<typeof InputLocators> {}
 /**
  * Page object representing a quick pick option in the input box
  *
  * @category Workbench
  */
-@PluginDecorator(InputLocators)
+@PageDecorator(InputLocators)
 export class QuickPickItem extends BasePage<typeof InputLocators> {
     /**
      * @private
@@ -279,13 +279,13 @@ export class QuickPickItem extends BasePage<typeof InputLocators> {
     }
 }
 
-export interface InputBox extends IPluginDecorator<typeof InputBoxLocators> {}
+export interface InputBox extends IPageDecorator<typeof InputBoxLocators> {}
 /**
  * Plain input box variation of the input page object
  *
  * @category Workbench
  */
-@PluginDecorator({ ...InputLocators, ...InputBoxLocators })
+@PageDecorator({ ...InputLocators, ...InputBoxLocators })
 export class InputBox extends Input {
     /**
      * @private
@@ -340,14 +340,14 @@ export class InputBox extends Input {
     }
 }
 
-export interface QuickOpenBox extends IPluginDecorator<AllInputLocators> {}
+export interface QuickOpenBox extends IPageDecorator<AllInputLocators> {}
 /**
  * @deprecated as of VS Code 1.44.0, quick open box has been replaced with input box
  * The quick open box variation of the input
  *
  * @category Workbench
  */
-@PluginDecorator({ ...InputLocators, ...QuickOpenBoxLocators })
+@PageDecorator({ ...InputLocators, ...QuickOpenBoxLocators })
 export class QuickOpenBox extends Input {
     /**
      * @private

--- a/src/pageobjects/workbench/Notification.ts
+++ b/src/pageobjects/workbench/Notification.ts
@@ -1,6 +1,6 @@
 import { ChainablePromiseElement } from 'webdriverio'
 import {
-    BasePage, IPluginDecorator, PluginDecorator, VSCodeLocatorMap
+    BasePage, IPageDecorator, PageDecorator, VSCodeLocatorMap
 } from '../utils'
 import { Notification as NotificationLocators } from '../../locators/1.61.0'
 
@@ -15,7 +15,7 @@ export enum NotificationType {
     Any = 'any'
 }
 
-interface NotificationButton extends IPluginDecorator<typeof NotificationLocators> {}
+interface NotificationButton extends IPageDecorator<typeof NotificationLocators> {}
 /**
  * Notification button
  *
@@ -42,7 +42,7 @@ class NotificationButton extends BasePage<typeof NotificationLocators> {
     }
 }
 
-export interface Notification extends IPluginDecorator<typeof NotificationLocators> {}
+export interface Notification extends IPageDecorator<typeof NotificationLocators> {}
 /**
  * Abstract element representing a notification
  *
@@ -156,7 +156,7 @@ export abstract class Notification extends BasePage<typeof NotificationLocators>
  *
  * @category Workbench
  */
-@PluginDecorator(NotificationLocators)
+@PageDecorator(NotificationLocators)
 export class StandaloneNotification extends Notification {
     /**
      * @private
@@ -176,7 +176,7 @@ export class StandaloneNotification extends Notification {
  *
  * @category Workbench
  */
-@PluginDecorator(NotificationLocators)
+@PageDecorator(NotificationLocators)
 export class CenterNotification extends Notification {
     /**
      * @private

--- a/src/pageobjects/workbench/NotificationsCenter.ts
+++ b/src/pageobjects/workbench/NotificationsCenter.ts
@@ -1,14 +1,14 @@
 import { Notification, CenterNotification, NotificationType } from './Notification'
-import { BasePage, PluginDecorator, IPluginDecorator } from '../utils'
+import { BasePage, PageDecorator, IPageDecorator } from '../utils'
 import { NotificationsCenter as NotificationsCenterLocator } from '../../locators/1.61.0'
 
-export interface NotificationsCenter extends IPluginDecorator<typeof NotificationsCenterLocator> {}
+export interface NotificationsCenter extends IPageDecorator<typeof NotificationsCenterLocator> {}
 /**
  * Notifications center page object
  *
  * @category Workbench
  */
-@PluginDecorator(NotificationsCenterLocator)
+@PageDecorator(NotificationsCenterLocator)
 export class NotificationsCenter extends BasePage<typeof NotificationsCenterLocator> {
     /**
      * @private

--- a/src/pageobjects/workbench/Workbench.ts
+++ b/src/pageobjects/workbench/Workbench.ts
@@ -9,16 +9,16 @@ import { NotificationsCenter } from './NotificationsCenter'
 import { QuickOpenBox, InputBox } from './Input'
 import { SettingsEditor } from '../editor/SettingsEditor'
 
-import { PluginDecorator, IPluginDecorator, BasePage } from '../utils'
+import { PageDecorator, IPageDecorator, BasePage } from '../utils'
 import { Workbench as WorkbenchLocators } from '../../locators/1.61.0'
 
-export interface Workbench extends IPluginDecorator<typeof WorkbenchLocators> {}
+export interface Workbench extends IPageDecorator<typeof WorkbenchLocators> {}
 /**
  * Page object representing the custom VSCode title bar
  *
  * @category Workbench
  */
-@PluginDecorator(WorkbenchLocators)
+@PageDecorator(WorkbenchLocators)
 export class Workbench extends BasePage<typeof WorkbenchLocators> {
     /**
      * @private

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -4,7 +4,7 @@
 
 import path from 'path'
 import {
-    PluginDecorator, IPluginDecorator, BasePage, BottomBarPanel,
+    PageDecorator, IPageDecorator, BasePage, BottomBarPanel,
     StatusBar, SettingsEditor, TextEditor, FindWidget, MarkerType, ProblemsView, EditorView
 } from '../..'
 
@@ -20,8 +20,8 @@ const locators = {
     }
 }
 
-interface TestPageObject extends IPluginDecorator<typeof locators.marquee> {}
-@PluginDecorator(locators.marquee)
+interface TestPageObject extends IPageDecorator<typeof locators.marquee> {}
+@PageDecorator(locators.marquee)
 class TestPageObject extends BasePage<typeof locators.marquee, typeof locators> {
     public locatorKey = 'marquee' as const
 
@@ -33,7 +33,7 @@ class TestPageObject extends BasePage<typeof locators.marquee, typeof locators> 
 describe('WDIO VSCode Service', () => {
     describe('page objects', () => {
         it('exports necessary components for custom pageobjects', () => {
-            expect(typeof PluginDecorator).toBe('function')
+            expect(typeof PageDecorator).toBe('function')
             expect(typeof BasePage).toBe('function')
         })
 


### PR DESCRIPTION
The term `PluginDecorator` doesn't really fit for what it does. It is a relict from when I fiddled around with the Page Object set up. Let's rename it before it is too late.