### PR TITLE
patch currentText being null in Workbench Input setText

### DIFF
--- a/src/pageobjects/workbench/Input.ts
+++ b/src/pageobjects/workbench/Input.ts
@@ -47,8 +47,10 @@ export abstract class Input extends BasePage<AllInputLocators> {
         const currentText = await this.getText()
         if (currentText !== text) {
             await clipboard.write(text)
-            const backSpaces = new Array(currentText.length).fill('Backspace')
-            await input.addValue(backSpaces)
+            if (currentText?.length) {
+                const backSpaces = new Array(currentText.length).fill('Backspace')
+                await input.addValue(backSpaces)
+            }
             await clipboard.write('')
         }
     }


### PR DESCRIPTION
Discovered an issue with trying to use `workbench.executeCommand` when trying to upgrade https://github.com/iterative/vscode-dvc to v4 of the service.

As detailed here: https://github.com/webdriverio-community/wdio-vscode-service/pull/17/files#r926271996