### PR TITLE
Avoiding '--no-<option>' to be parsed as '--<option>=false'

### DIFF
--- a/src/chromium/index.ts
+++ b/src/chromium/index.ts
@@ -22,7 +22,7 @@ function run (p: NodeJS.Process, execFile: typeof childProcess.execFile) {
 
     // eslint-disable-next-line @typescript-eslint/naming-convention
     const { _: positionalParams, ...argv } = argvParser(process.argv.slice(2), {
-        configuration: { 'camel-case-expansion': true }
+        configuration: { 'camel-case-expansion': true, 'boolean-negation': false }
     })
 
     const binaryPath = argv.vscodeBinaryPath as string


### PR DESCRIPTION
(Comes from https://github.com/webdriverio-community/wdio-vscode-service/issues/28)
Currently, option `--no-foo` prefix will be forwarded to chromium process as `--foo=false`. As we need the option `--no-sandbox` to be passed literally to chromium, we change parser configuration to avoid performing translation `--sandbox=false`.