### PR TITLE
executeWorkbench args

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -269,7 +269,7 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
 interface VSCodeCommands {
     getWorkbench: () => Promise<Workbench>
     // Todo(Christian): properly type VSCode object here
-    executeWorkbench: <T>(fn: (vscode: any, ...params: any[]) => T) => Promise<T>
+    executeWorkbench: <T>(fn: (vscode: any, ...params: any[]) => T, ...params: any[]) => Promise<T>
     getVSCodeVersion: () => Promise<string>
     getVSCodeChannel: () => Promise<string>
     isVSCodeWebSession: () => Promise<boolean>

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -116,6 +116,22 @@ describe('WDIO VSCode Service', () => {
                 timeoutMsg: 'Could not find another custom notification'
             })
         })
+
+        it('can send parameters to VSCode API invocation', async () => {
+            const workbench = await browser.getWorkbench()
+            const message = 'I passed this message as a parameter!'
+            await browser.executeWorkbench((vscode, msg) => {
+                // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+                vscode.window.showInformationMessage(msg)
+            }, message)
+            await browser.waitUntil(async () => {
+                const notifs = await workbench.getNotifications()
+                const messages = await Promise.all(notifs.map((n) => n.getMessage()))
+                return messages.includes(message)
+            }, {
+                timeoutMsg: 'Could not find custom notification'
+            })
+        })
     })
 
     describe('settings @skipWeb', () => {

--- a/test/specs/basic.e2e.ts
+++ b/test/specs/basic.e2e.ts
@@ -117,7 +117,7 @@ describe('WDIO VSCode Service', () => {
             })
         })
 
-        it('can send parameters to VSCode API invocation', async () => {
+        it('can send parameters to VSCode API invocation @skipWeb', async () => {
             const workbench = await browser.getWorkbench()
             const message = 'I passed this message as a parameter!'
             await browser.executeWorkbench((vscode, msg) => {


### PR DESCRIPTION
Currently, `VSCodeCommands` interface doesn't allow to pass parameters to `executeWorkbench` method. We add the parameters args to its signature.

~~Additionally, mocha invert flag is set to its default value.~~