### PR TITLE
Expose `storagePath` as a config in vscodeOptions capability field

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,16 @@ Define the directory to the extension you want to test.
 
 Type: `string`
 
+#### `storagePath`
+
+Define a custom location for VS Code to store all its data. This is the root for internal VS Code directories such as (partial list) 
+* **user-data-dir**: The directory where all the user settings (global settings), extension logs etc are stored.
+* **extension-install-dir**: The directory where VS Code extensions are installed. 
+
+If not provided, a temporary directory is used. 
+
+Type: `string`
+
 #### `userSettings`
 
 Define custom user settings to be applied to VSCode.

--- a/src/service.ts
+++ b/src/service.ts
@@ -50,7 +50,6 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             }
 
             resolver(message.error, message.result)
-            return
         } catch (err: any) {
             log.error(`Error parsing remote response: ${err.message}`)
         }
@@ -81,8 +80,8 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         }
 
         const customArgs: ArgsParams = { ...VSCODE_APPLICATION_ARGS }
-        const storagePath = await tmp.dir()
-        const userSettingsPath = path.join(storagePath.path, 'settings', 'User')
+        const storagePath = this._vscodeOptions.storagePath ?? (await tmp.dir()).path
+        const userSettingsPath = path.join(storagePath, 'settings', 'User')
         const userSettings: Record<string, any> = {
             ...DEFAULT_VSCODE_SETTINGS,
             ...(this._vscodeOptions.userSettings || {})
@@ -113,8 +112,8 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
 
         customArgs.extensionDevelopmentPath = slash(this._vscodeOptions.extensionPath)
         customArgs.extensionTestsPath = slash(path.join(__dirname, 'proxy', 'cjs', 'entry.js'))
-        customArgs.userDataDir = slash(path.join(storagePath.path, 'settings'))
-        customArgs.extensionsDir = slash(path.join(storagePath.path, 'extensions'))
+        customArgs.userDataDir = slash(path.join(storagePath, 'settings'))
+        customArgs.extensionsDir = slash(path.join(storagePath, 'extensions'))
         customArgs.vscodeBinaryPath = this._vscodeOptions.binary as string
 
         log.info(`Setting up VSCode directory at ${userSettingsPath}`)

--- a/src/types.ts
+++ b/src/types.ts
@@ -133,6 +133,11 @@ export interface VSCodeOptions {
      * Define options when testing VSCode web extensions
      */
     serverOptions?: ServerOptions
+
+    /**
+     * Define a custom location for vscode to store all its data (root for extensionPath, userDataDir etc)
+     */
+    storagePath?: string
 }
 
 export interface WDIOLogs {


### PR DESCRIPTION
Fixes #74 