### PR TITLE
Bug fix for import('vscode-uri').default

### DIFF
--- a/src/pageobjects/editor/TextEditor.ts
+++ b/src/pageobjects/editor/TextEditor.ts
@@ -2,6 +2,7 @@ import { fileURLToPath } from 'node:url'
 import clipboard from 'clipboardy'
 import { Key, ChainablePromiseElement } from 'webdriverio'
 
+import logger from '@wdio/logger'
 import { ContentAssist, ContextMenu, InputBox } from '../index.js'
 import { StatusBar } from '../statusBar/StatusBar.js'
 import { Editor, EditorLocators } from './Editor.js'
@@ -14,6 +15,8 @@ import {
     FindWidget as FindWidgetLocators
 } from '../../locators/1.73.0.js'
 import { CMD_KEY } from '../../constants.js'
+
+const log = logger('wdio-vscode-service')
 
 export interface TextEditor extends IPageDecorator<EditorLocators> {}
 /**
@@ -370,7 +373,7 @@ export class TextEditor extends Editor<EditorLocators> {
         try {
             await menu.select('Format Document')
         } catch (err) {
-            console.log('Warn: Format Document not available for selected language')
+            log.error('Warn: Format Document not available for selected language')
             if (await menu.elem.isDisplayed()) {
                 await menu.close()
             }

--- a/src/pageobjects/menu/WindowControls.ts
+++ b/src/pageobjects/menu/WindowControls.ts
@@ -1,10 +1,13 @@
 import type { ChainablePromiseElement } from 'webdriverio'
 
+import logger from '@wdio/logger'
 import {
     PageDecorator, IPageDecorator, BasePage, VSCodeLocatorMap
 } from '../utils.js'
 import { TitleBar } from '../../index.js'
 import { WindowControls as WindowControlsLocators } from '../../locators/1.73.0.js'
+
+const log = logger('wdio-vscode-service')
 
 export interface WindowControls extends IPageDecorator<typeof WindowControlsLocators> {}
 /**
@@ -44,7 +47,7 @@ export class WindowControls extends BasePage<typeof WindowControlsLocators> {
         try {
             await this.maximize$.click()
         } catch (err) {
-            console.log('Window is already maximized')
+            log.error('Window is already maximized', err)
         }
     }
 
@@ -56,7 +59,7 @@ export class WindowControls extends BasePage<typeof WindowControlsLocators> {
         try {
             await this.restore$.click()
         } catch (err) {
-            console.log('Window is not maximized')
+            log.error('Window is not maximized', err)
         }
     }
 

--- a/src/server/utils.ts
+++ b/src/server/utils.ts
@@ -3,7 +3,8 @@ import path from 'node:path'
 
 import { fsProviderExtensionPrefix, fsProviderFolderUri } from './constants.js'
 
-const { URI } = (await import('vscode-uri')).default
+const vscodeUri = await import('vscode-uri')
+const { URI } = vscodeUri.default ? vscodeUri.default : vscodeUri
 
 export interface IConfig {
     readonly extensionPaths: string[] | undefined


### PR DESCRIPTION
Fix for issue [#81](https://github.com/mikhail-g/wdio-vscode-service/issues/81) and 
[#88](https://github.com/webdriverio-community/wdio-vscode-service/issues/88)

Fresh `wdio-vscode-service` project is not starting because of `import('vscode-uri').default`
Error message:
`TypeError: Cannot destructure property 'URI' of
'(intermediate value).default' as it is undefined`

- The solution has used already at `@wdio/utils/build/utils.js:204`
- The import that was changed here has been working without `.default` 11 month ago,
before the change [1562cd1](https://github.com/webdriverio-community/wdio-vscode-service/commit/1562cd19185af40f2269daa0574bb130201ab557)