### PR TITLE
fix: Prevent "TypeError: object is not iterable"

### DIFF
--- a/src/pageobjects/editor/EditorView.ts
+++ b/src/pageobjects/editor/EditorView.ts
@@ -301,13 +301,11 @@ export class EditorGroup extends BasePage<typeof EditorViewLocators> {
      * @returns promise resolving to EditorTab list
      */
     async getOpenTabs (): Promise<EditorTab[]> {
-        const tabs = await this.tab$$
-        return Promise.all(
-            tabs.map(async (tab) => (
-                // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-                new EditorTab(this.locatorMap, tab as any, this.view).wait()
-            ))
-        )
+        const tabs = this.tab$$
+        return tabs.map(async (tab) => (
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+            new EditorTab(this.locatorMap, tab as any, this.view).wait()
+        ))
     }
 
     /**

--- a/test/specs/editor.e2e.ts
+++ b/test/specs/editor.e2e.ts
@@ -1,0 +1,17 @@
+/* eslint-disable @typescript-eslint/no-unsafe-return */
+/* eslint-disable @typescript-eslint/no-unsafe-call */
+// eslint-disable-next-line @typescript-eslint/triple-slash-reference
+/// <reference path="../../dist/service.d.ts" />
+
+import { browser, expect } from '@wdio/globals'
+
+describe('editor', () => {
+    describe('getOpenTabs', () => {
+        it('returns an empty array when no tabs are open', async () => {
+            const workbench = await browser.getWorkbench()
+            await workbench.getEditorView().closeAllEditors()
+
+            expect(await workbench.getEditorView().getOpenTabs()).toStrictEqual([])
+        })
+    })
+})


### PR DESCRIPTION
### Context

This PR is a workaround for the bug described in #100 but doesn't address the root cause. Sorry.

### Proposed Changes

* Add a failing test that shows:
    ```
    TypeError: object is not iterable (cannot read property Symbol(Symbol.iterator)
            at EditorGroup.getOpenTabs
    ```
* Change the implementation to workaround the issue. `this.tabs$$.map` works but `(await this.tabs$$).map` doesn't. :shrug:

### Notes

To set expectations, I'm offline until Sunday night. Feel free to change anything you'd like Christian.
