### PR TITLE
Make executeWorkbench work after VSCode restarts

### DIFF
--- a/test/specs/workbench.e2e.ts
+++ b/test/specs/workbench.e2e.ts
@@ -86,7 +86,7 @@ describe('workbench', () => {
         })
     })
 
-    it('can access the VSCode API after a new folder is opened', async () => {
+    it('can access the VSCode API after a new folder is opened @skipWeb', async () => {
         const workspaceRoot = await browser.executeWorkbench<string | undefined>((vscode) => vscode.workspace.rootPath)
         expect(workspaceRoot).not.toBe(undefined)
         const newWorkspaceRoot = path.join(workspaceRoot!, 'test')

--- a/test/specs/workbench.e2e.ts
+++ b/test/specs/workbench.e2e.ts
@@ -86,7 +86,7 @@ describe('workbench', () => {
         })
     })
 
-    it('can assess VSCode API after new folder is opened', async () => {
+    it('can access the VSCode API after a new folder is opened', async () => {
         const workspaceRoot = await browser.executeWorkbench<string | undefined>((vscode) => vscode.workspace.rootPath)
         expect(workspaceRoot).not.toBe(undefined)
         const newWorkspaceRoot = path.join(workspaceRoot!, 'test')

--- a/test/specs/workbench.e2e.ts
+++ b/test/specs/workbench.e2e.ts
@@ -3,6 +3,7 @@
 // eslint-disable-next-line @typescript-eslint/triple-slash-reference
 /// <reference path="../../dist/service.d.ts" />
 
+import path from 'node:path'
 import { browser, expect } from '@wdio/globals'
 import { skip } from './utils.js'
 
@@ -82,6 +83,20 @@ describe('workbench', () => {
             return messages.includes('I am an another API call!')
         }, {
             timeoutMsg: 'Could not find another custom notification'
+        })
+    })
+
+    it('can assess VSCode API after new folder is opened', async () => {
+        const workspaceRoot = await browser.executeWorkbench<string | undefined>((vscode) => vscode.workspace.rootPath)
+        expect(workspaceRoot).not.toBe(undefined)
+        const newWorkspaceRoot = path.join(workspaceRoot!, 'test')
+        await browser.executeWorkbench((vscode, newRoot) => {
+            const uri = vscode.Uri.file(newRoot)
+            vscode.commands.executeCommand('vscode.openFolder', uri)
+        }, newWorkspaceRoot)
+        await browser.waitUntil(async () => {
+            const root = await browser.executeWorkbench((vscode) => vscode.workspace.rootPath)
+            return root === newWorkspaceRoot
         })
     })
 


### PR DESCRIPTION
`vscode.openFolder` can be used to restart the VSCode under different workspace root. In that case the current socket is closed, and then the new connection appears after the VSCode is up again.

This PR clears pending message callbacks when the connection is closed and re-assigns the `_promisedSocket` to a new socket when new connection appears.

Fixes https://github.com/webdriverio-community/wdio-vscode-service/issues/62

Had to hard-code vscode version to `1.85.2` when running tests locally, since newer chromedriver versions live in a new location. Seems like there's a PR already to fix it https://github.com/webdriverio-community/wdio-vscode-service/pull/105