### PR TITLE
Fix problems with cachePath service option

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -11,9 +11,7 @@ import type { Capabilities } from '@wdio/types'
 import { HttpsProxyAgent } from 'hpagent'
 
 import startServer from './server/index.js'
-import {
-    fileExist, directoryExists, isMultiremote, isChrome
-} from './utils.js'
+import { fileExist, directoryExists } from './utils.js'
 import {
     DEFAULT_CHANNEL, VSCODE_RELEASES, VSCODE_MANIFEST_URL, DEFAULT_CACHE_PATH,
     VSCODE_CAPABILITY_KEY, VSCODE_WEB_STANDALONE, DEFAULT_VSCODE_WEB_HOSTNAME
@@ -64,10 +62,7 @@ export default class VSCodeServiceLauncher {
     private _cachePath: string
     private _vscodeServerPort?: number
 
-    constructor (
-        private _options: ServiceOptions,
-        private _capabilities: WebdriverIO.Capabilities
-    ) {
+    constructor (private _options: ServiceOptions) {
         this._cachePath = this._options.cachePath || DEFAULT_CACHE_PATH
     }
 
@@ -105,7 +100,6 @@ export default class VSCodeServiceLauncher {
              * setup VSCode Web
              */
             await this._setupVSCodeWeb(version, cap)
-            this._mapBrowserCapabilities(this._options)
         }
     }
 
@@ -168,8 +162,6 @@ export default class VSCodeServiceLauncher {
                 log.info(
                     `Skipping download, bundle for VSCode v${vscodeVersion} already exists`
                 )
-
-                Object.assign(cap, this._options)
                 cap.browserVersion = chromedriverVersion
                 cap[VSCODE_CAPABILITY_KEY].binary ||= await this._downloadVSCode(vscodeVersion)
                 return
@@ -179,7 +171,6 @@ export default class VSCodeServiceLauncher {
         const vscodeVersion = await this._fetchVSCodeVersion(version)
         const chromedriverVersion = await this._fetchChromedriverVersion(vscodeVersion)
 
-        Object.assign(cap, this._options)
         cap.browserVersion = chromedriverVersion
         cap[VSCODE_CAPABILITY_KEY].binary ||= await this._downloadVSCode(vscodeVersion)
         await this._updateVersionsTxt(version, vscodeVersion, chromedriverVersion, versionsFileExist)
@@ -314,17 +305,5 @@ export default class VSCodeServiceLauncher {
             JSON.stringify({ ...content, ...newContent }, null, 4),
             'utf-8'
         )
-    }
-
-    private _mapBrowserCapabilities (options: ServiceOptions) {
-        if (isMultiremote(this._capabilities)) {
-            throw new SevereServiceError('This service doesn\'t support multiremote yet')
-        }
-
-        for (const cap of this._capabilities as any as WebdriverIO.Capabilities[]) {
-            if (isChrome(cap)) {
-                Object.assign(cap, options)
-            }
-        }
     }
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -74,6 +74,3 @@ export function getFileType (stats: Stats | Dirent) {
 
     return FileType.Unknown
 }
-
-export const isMultiremote = (obj: any) => typeof obj === 'object' && !Array.isArray(obj)
-export const isChrome = (cap: VSCodeCapabilities) => cap.browserName && cap.browserName.toLowerCase() === 'chrome'


### PR DESCRIPTION
Using the `vscode` service with the `cachePath` option:
```js
services: [["vscode", {cachePath: "/tmp/wdio-vscode-service"}]],
```

On the `6.0.0` version this results in a failure to run tests:
```
ERROR @wdio/runner: Error: Invalid or unsupported WebDriver capabilities found ("cachePath"). Ensure to only use valid W3C WebDriver capabilities (see https://w3c.github.io/webdriver/#capabilities).If you run your tests on a remote vendor, like Sauce Labs or BrowserStack, make sure that you put them into vendor specific capabilities, e.g. "sauce:options" or "bstack:options". Please reach out to your vendor support team if you have further questions.
```

`cachePath` is indeed not a capability based on any of the wdio or webdriver types.

Looking at the old `5.*` code, assigning `options` to the capabilities made sense because `options` field actually contained [different things in the `wdio-chromedriver-service/launcher` base class](https://github.com/webdriverio-community/wdio-chromedriver-service/blob/104e63525faa156866aa521397ae56ffc6059a8f/src/launcher.ts#L47).

Right now the options are only relevant for the `vscode` service, so I've removed all logic that merges them into capabilities.