### PR TITLE
(ci): Add manual workflow trigger with Node.js version parameter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,3 +1,4 @@
+---
 name: CI
 
 on:
@@ -7,6 +8,17 @@ on:
     tags:
       - v[0-9]+.[0-9]+.[0-9]+*
   pull_request:
+  workflow_dispatch:
+    inputs:
+      node_version:
+        description: 'Node.js version'
+        required: true
+        default: 18
+        type: choice
+        options:
+          - 16
+          - 18
+          - 20
 
 jobs:
   build:
@@ -25,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: 18
+          node-version: ${{ inputs.print_tags || 18 }}
       - name: Install Dependencies
         run: npm ci
         env:
@@ -44,4 +56,3 @@ jobs:
         with:
           name: screenshots
           path: test/screenshots
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ inputs.print_tags || 18 }}
+          node-version: ${{ inputs.node_version }}
       - name: Install Dependencies
         run: npm ci
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: ${{ inputs.node_version }}
+          node-version: ${{ inputs.node_version || 18 }}
       - name: Install Dependencies
         run: npm ci
         env:


### PR DESCRIPTION
### Proposed Changes

* Add an on-demand way to run CI pipeline with Node v16

### Notes

Not sure if you'd want this in the repo. :shrug: If solves the need to test Node 16 ad hoc without running it all the time.