### PR TITLE
fix: Copy terminal selection on Linux

### DIFF
--- a/src/pageobjects/bottomBar/Views.ts
+++ b/src/pageobjects/bottomBar/Views.ts
@@ -189,7 +189,10 @@ export class TerminalView extends ChannelView<typeof TerminalViewLocators> {
         await workbench.executeCommand('terminal select all')
         // eslint-disable-next-line wdio/no-pause
         await browser.pause(500)
-        await browser.keys([Key.Ctrl, 'c'])
+        await browser.executeWorkbench((vscode) => {
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
+            vscode.commands.executeCommand('workbench.action.terminal.copySelection')
+        })
         // eslint-disable-next-line wdio/no-pause
         await browser.pause(500)
         const text = await clipboard.read()

--- a/test/specs/bottombar.e2e.ts
+++ b/test/specs/bottombar.e2e.ts
@@ -34,9 +34,9 @@ describe('bottombar', () => {
         expect(await outputView.getText()).toEqual(['Hello World!'])
     })
 
-    skip('CI')('can read from terminal @skipWeb', async () => {
+    it('can read from terminal @skipWeb', async () => {
         const terminalView = await bottomBar.openTerminalView()
         const text = await terminalView.getText()
-        expect(text).toContain(':wdio-vscode-service')
+        expect(text).toContain('wdio-vscode-service')
     })
 })


### PR DESCRIPTION
This will close #103.

> ### Problem
> 
> We assume the command to copy from the terminal is <kbd>Ctrl</kbd>-<kbd>-c</kbd>:
> 
> ```
> [chrome 114.0.5735.289 linux #0-0] » /test/specs/bottombar.e2e.ts
> [chrome 114.0.5735.289 linux #0-0] bottombar
> [chrome 114.0.5735.289 linux #0-0]    ✖ can read from terminal @skipWeb

### Proposed Changes

- ﻿fix: Copy terminal selection on Linux
- test: Enable passing tests
