### PR TITLE
fix: Prevent "Connection closed" errors when deleting the session for @wdio/cucumber-framework

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -57,11 +57,12 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
     }
 
     private _handleSocketClose (code: number, reason: Buffer) {
-        if (!this._deletingSession) {
-            const msg = `Connection closed. Code: ${code}, reason: ${reason.toString()}`
-            this._promisedSocket = Promise.reject(new Error(msg))
-            this._pendingMessages.forEach((resolver) => resolver(msg, null))
+        if (this._deletingSession) {
+            return
         }
+        const msg = `Connection closed. Code: ${code}, reason: ${reason.toString()}`
+        this._promisedSocket = Promise.reject(new Error(msg))
+        this._pendingMessages.forEach((resolver) => resolver(msg, null))
     }
 
     async beforeSession (option: Options.Testrunner, capabilities: VSCodeCapabilities) {


### PR DESCRIPTION
### Proposed Changes

This fixes #115.

### Validation

Since we don't have Cucumber set up in this repo I used [seanpoulter/wdio-vscode-cucumber-example](https://github.com/seanpoulter/wdio-vscode-cucumber-example):

```
$ cd .../wdio-vscode-﻿service
$ npm link
$ npm run build

$ cd .../wdio-vscode-cucumber-example
$ npm link wdio-vscode-service

$ npm run test


> test
> wdio run ./test/wdio.conf.ts


Execution of 1 workers started at 2024-02-27T01:45:04.115Z

Skipping download, bundle for ChromeDriver v27.2.3 already exists
Found existing install in .../.wdio-vscode-service/vscode-linux-arm64-1.86.2. Skipping download
[0-0] RUNNING in chrome - file:///test/features/webview.feature
[0-0] PASSED in chrome - file:///test/features/webview.feature

 "spec" Reporter:
------------------------------------------------------------------
[chrome 118.0.5993.159 linux #0-0] Running: chrome (v118.0.5993.159) on linux
[chrome 118.0.5993.159 linux #0-0] Session ID: 90871adafb5727ca052e30dc884ec9e9
[chrome 118.0.5993.159 linux #0-0]
[chrome 118.0.5993.159 linux #0-0] » /test/features/webview.feature
[chrome 118.0.5993.159 linux #0-0] Hello World
[chrome 118.0.5993.159 linux #0-0] As an extension developer
[chrome 118.0.5993.159 linux #0-0] I want to test if a Webview is displayed
[chrome 118.0.5993.159 linux #0-0]
[chrome 118.0.5993.159 linux #0-0] Webview Shows "Hello World!"
[chrome 118.0.5993.159 linux #0-0]    ✓ When I open the Webview
[chrome 118.0.5993.159 linux #0-0]    ✓ Then I expect that "Hello World!" is displayed
[chrome 118.0.5993.159 linux #0-0]
[chrome 118.0.5993.159 linux #0-0] 2 passing (3.2s)


Spec Files:      1 passed, 1 total (100% completed) in 00:00:10  
```

:tada:
