### PR TITLE
feat: support string array for ArgParams

### DIFF
--- a/src/service.ts
+++ b/src/service.ts
@@ -160,14 +160,15 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         const binary = path.join(__dirname, 'chromium', `index.${process.platform === 'win32' ? 'exe' : 'js'}`)
         const args = Object.entries({ ...customArgs, ...this._vscodeOptions.vscodeArgs }).reduce(
             (prev, [key, value]) => {
+                const decamelizedKey = decamelize(key, { separator: '-' })
                 if (Array.isArray(value)) {
                     const expandedArgs = value.map(
-                        (val) => `--${decamelize(key, { separator: '-' })}${getValueSuffix(val)}`
+                        (val) => `--${decamelizedKey}${getValueSuffix(val)}`
                     )
                     return [...prev, ...expandedArgs]
                 }
 
-                return [...prev, `--${decamelize(key, { separator: '-' })}${getValueSuffix(value)}`]
+                return [...prev, `--${decamelizedKey}${getValueSuffix(value)}`]
             },
             [] as string[]
         )

--- a/src/service.ts
+++ b/src/service.ts
@@ -161,7 +161,9 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         const args = Object.entries({ ...customArgs, ...this._vscodeOptions.vscodeArgs }).reduce(
             (prev, [key, value]) => [
                 ...prev,
-                `--${decamelize(key, { separator: '-' })}${getValueSuffix(value)}`
+                Array.isArray(value) ? value.reduce((all: string, val) => {
+                    return all + `--${decamelize(key, { separator: '-' })}${getValueSuffix(val)} `;
+                }, "").trim() : `--${decamelize(key, { separator: '-' })}${getValueSuffix(value)}`
             ],
             [] as string[]
         )

--- a/src/service.ts
+++ b/src/service.ts
@@ -159,12 +159,16 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
 
         const binary = path.join(__dirname, 'chromium', `index.${process.platform === 'win32' ? 'exe' : 'js'}`)
         const args = Object.entries({ ...customArgs, ...this._vscodeOptions.vscodeArgs }).reduce(
-            (prev, [key, value]) => [
-                ...prev,
-                Array.isArray(value) ? value.reduce((all: string, val) => {
-                    return all + `--${decamelize(key, { separator: '-' })}${getValueSuffix(val)} `;
-                }, "").trim() : `--${decamelize(key, { separator: '-' })}${getValueSuffix(value)}`
-            ],
+            (prev, [key, value]) => {
+                if (Array.isArray(value)) {
+                    const expandedArgs = value.map(
+                        (val) => `--${decamelize(key, { separator: '-' })}${getValueSuffix(val)}`
+                    )
+                    return [...prev, ...expandedArgs]
+                }
+
+                return [...prev, `--${decamelize(key, { separator: '-' })}${getValueSuffix(value)}`]
+            },
             [] as string[]
         )
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -52,7 +52,7 @@ export interface ServerOptions {
     port: number
 }
 
-export type ArgsParams = Record<string, string | boolean>
+export type ArgsParams = Record<string, string | string[] | boolean>
 
 /**
  * wdio-vscode-service options


### PR DESCRIPTION
This PR adds support for the `string[]` type when passing arguments to VS Code. 
One use case that this enables is installing multiple extensions for a test scenario using the `--install-extension` parameter.