### PR TITLE
fix: locator selection and outputChannel selector

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -88,7 +88,7 @@ export default class VSCodeServiceLauncher {
 
             const version = cap[VSCODE_CAPABILITY_KEY].version || cap.browserVersion || DEFAULT_CHANNEL
             cap[VSCODE_CAPABILITY_KEY].version = version
-            
+
             /**
              * setup VSCode Desktop
              */

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -87,7 +87,8 @@ export default class VSCodeServiceLauncher {
             }
 
             const version = cap[VSCODE_CAPABILITY_KEY].version || cap.browserVersion || DEFAULT_CHANNEL
-
+            cap[VSCODE_CAPABILITY_KEY].version = version
+            
             /**
              * setup VSCode Desktop
              */

--- a/src/locators/1.87.0.ts
+++ b/src/locators/1.87.0.ts
@@ -1,0 +1,9 @@
+import { BottomBarViews as BottomBarViewsImport } from './1.84.0.js'
+
+export * from './1.84.0.js'
+export const locatorVersion = '1.87.0'
+
+export const BottomBarViews = {
+    ...BottomBarViewsImport,
+    outputChannels: 'ul[aria-label="Output actions"] select'
+}

--- a/src/locators/insiders.ts
+++ b/src/locators/insiders.ts
@@ -1,8 +1,8 @@
 import {
     QuickOpenBox as QuickOpenBoxImport
-} from './1.84.0.js'
+} from './1.87.0.js'
 
-export * from './1.84.0.js'
+export * from './1.87.0.js'
 export const locatorVersion = 'insiders'
 export const QuickOpenBox = {
     ...QuickOpenBoxImport,

--- a/src/pageobjects/bottomBar/AbstractViews.ts
+++ b/src/pageobjects/bottomBar/AbstractViews.ts
@@ -37,7 +37,7 @@ export abstract class ChannelView<T> extends ElementWithContextMenu<T> {
      */
     async getCurrentChannel (): Promise<string> {
         const combo = await this.parent.$(this.locatorMap.BottomBarViews.channelCombo as string)
-        return combo.getAttribute('title')
+        return combo.getValue()
     }
 
     /**

--- a/src/pageobjects/workbench/Input.ts
+++ b/src/pageobjects/workbench/Input.ts
@@ -29,7 +29,7 @@ export abstract class Input extends BasePage<AllInputLocators> {
      */
     async getText (): Promise<string> {
         const input = await this.inputBox$.$(this.locators.input)
-        return input.getAttribute('value')
+        return input.getValue()
     }
 
     /**

--- a/src/service.ts
+++ b/src/service.ts
@@ -203,12 +203,13 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             await browser.url('/')
         }
 
+        const vsCodeVersion = capabilities[VSCODE_CAPABILITY_KEY]?.version || capabilities.browserVersion || 'insiders'
         this._browser = browser
-        const locators = await getLocators(capabilities.browserVersion || 'insiders')
+        const locators = await getLocators(vsCodeVersion)
         const workbenchPO = new Workbench(locators)
         this._browser.addCommand('getWorkbench', () => workbenchPO.wait())
         this._browser.addCommand('executeWorkbench', this._executeVSCode.bind(this))
-        this._browser.addCommand('getVSCodeVersion', () => capabilities.browserVersion)
+        this._browser.addCommand('getVSCodeVersion', () => vsCodeVersion)
         this._browser.addCommand('isVSCodeWebSession', () => this._isWebSession)
         this._browser.addCommand('getVSCodeChannel', () => (
             capabilities.browserVersion === 'insiders' ? 'insiders' : 'vscode'


### PR DESCRIPTION
    The locator selection by vscode version did not work, because the vscode version was overwritten by the underlying chrome version and "122" was larger than all vscode versions. The vscode version is now preserved and use for locator selection.

    As of vscode 1.87.0 the bottombar's outputChanel selector does not have an attribute title anymore. The locator for 1.87.0 was thus added.