### PR TITLE
Use semver instead of unreliable string comparison

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           VSCODE_VERSION: ${{ matrix.vscodeVersion }}
           VSCODE_WEB_TESTS: ${{ matrix.vscodeVersion == 'web' && '1' || '0' }}
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         if: failure()
         with:
           name: screenshots

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,5 +1,8 @@
 {
-    "marquee.widgets.npm-stats.packageNames": [
-        "wdio-vscode-service"
-    ]
+  "marquee.widgets.npm-stats.packageNames": [
+    "wdio-vscode-service"
+  ],
+  "[typescript]": {
+    "editor.defaultFormatter": "dbaeumer.vscode-eslint"
+  },
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "fastify": "^4.26.1",
         "get-port": "7.0.0",
         "hpagent": "^1.2.0",
+        "semver": "^7.7.2",
         "slash": "^5.1.0",
         "tmp-promise": "^3.0.3",
         "undici": "^5.28.3",
@@ -11791,6 +11792,35 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/release-it/node_modules/semver": {
+      "version": "7.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
+      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "lru-cache": "^6.0.0"
+      },
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/release-it/node_modules/semver/node_modules/lru-cache": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "yallist": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/release-it/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -12119,12 +12149,10 @@
       "integrity": "sha512-6aU+Rwsezw7VR8/nyvKTx8QpWH9FrcYiXXlqC4z5d5XQBDRqtbfsRjnwGyqbi3gddNtWHuEk9OANUotL26qKUw=="
     },
     "node_modules/semver": {
-      "version": "7.6.0",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.6.0.tgz",
-      "integrity": "sha512-EnwXhrlwXMk9gKu5/flx5sv/an57AkRplG3hTK68W7FRDN+k+OWBj65M7719OkA82XLBxrcX0KSHj+X5COhOVg==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.2",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
+      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -12145,17 +12173,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/semver/node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/serialize-error": {
@@ -14320,7 +14337,9 @@
     "node_modules/yallist": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/yargs": {
       "version": "17.7.2",

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fastify": "^4.26.1",
     "get-port": "7.0.0",
     "hpagent": "^1.2.0",
+    "semver": "^7.7.2",
     "slash": "^5.1.0",
     "tmp-promise": "^3.0.3",
     "undici": "^5.28.3",

--- a/src/pageobjects/activityBar/ViewControl.ts
+++ b/src/pageobjects/activityBar/ViewControl.ts
@@ -1,4 +1,5 @@
 import type { ChainablePromiseElement } from 'webdriverio'
+import semver from 'semver'
 
 import {
     ActivityBar, DebugView, SideBarView, ScmView
@@ -57,7 +58,11 @@ export class ViewControl extends ElementWithContextMenu<typeof ViewControlLocato
         }
         const view = await new SideBarView(this.locatorMap).wait()
         if ((await view.elem.$$(this.locators.scmId)).length > 0) {
-            if (await browser.getVSCodeChannel() === 'vscode' && await browser.getVSCodeVersion() >= '1.47.0') {
+            const version = await browser.getVSCodeVersion()
+            if (
+                (await browser.getVSCodeChannel()) === 'vscode'
+                && semver.gte(version, '1.47.0')
+            ) {
                 return new NewScmView(this.locatorMap).wait()
             }
             return new ScmView(this.locatorMap).wait()

--- a/src/pageobjects/activityBar/ViewControl.ts
+++ b/src/pageobjects/activityBar/ViewControl.ts
@@ -1,5 +1,4 @@
 import type { ChainablePromiseElement } from 'webdriverio'
-import semver from 'semver'
 
 import {
     ActivityBar, DebugView, SideBarView, ScmView
@@ -7,7 +6,7 @@ import {
 import { NewScmView } from '../sidebar/scm/NewScmView.js'
 
 import {
-    PageDecorator, IPageDecorator, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, ElementWithContextMenu, VSCodeLocatorMap, semverGte
 } from '../utils.js'
 import { ViewControl as ViewControlLocators } from '../../locators/1.73.0.js'
 
@@ -61,7 +60,7 @@ export class ViewControl extends ElementWithContextMenu<typeof ViewControlLocato
             const version = await browser.getVSCodeVersion()
             if (
                 (await browser.getVSCodeChannel()) === 'vscode'
-                && semver.gte(version, '1.47.0')
+                && semverGte(version, '1.47.0')
             ) {
                 return new NewScmView(this.locatorMap).wait()
             }

--- a/src/pageobjects/editor/TextEditor.ts
+++ b/src/pageobjects/editor/TextEditor.ts
@@ -1,15 +1,13 @@
 import { fileURLToPath } from 'node:url'
 import clipboard from 'clipboardy'
-import semver from 'semver'
 import { Key, ChainablePromiseElement } from 'webdriverio'
 
 import logger from '@wdio/logger'
 import { ContentAssist, ContextMenu, InputBox } from '../index.js'
 import { StatusBar } from '../statusBar/StatusBar.js'
 import { Editor, EditorLocators } from './Editor.js'
-
 import {
-    PageDecorator, IPageDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap
+    PageDecorator, IPageDecorator, BasePage, ElementWithContextMenu, VSCodeLocatorMap, semverLt
 } from '../utils.js'
 import {
     TextEditor as TextEditorLocators,
@@ -633,7 +631,7 @@ export class FindWidget extends BasePage<typeof FindWidgetLocators> {
      */
     async nextMatch (): Promise<void> {
         const version = await browser.getVSCodeVersion()
-        const name = semver.lt(version, '1.59.0') ? 'Next match' : 'Next Match'
+        const name = semverLt(version, '1.59.0') ? 'Next match' : 'Next Match'
         await this.clickButton(name, 'find')
     }
 
@@ -642,7 +640,7 @@ export class FindWidget extends BasePage<typeof FindWidgetLocators> {
      */
     async previousMatch (): Promise<void> {
         const version = await browser.getVSCodeVersion()
-        const name = semver.lt(version, '1.59.0')
+        const name = semverLt(version, '1.59.0')
             ? 'Previous match'
             : 'Previous Match'
         await this.clickButton(name, 'find')

--- a/src/pageobjects/editor/TextEditor.ts
+++ b/src/pageobjects/editor/TextEditor.ts
@@ -1,5 +1,6 @@
 import { fileURLToPath } from 'node:url'
 import clipboard from 'clipboardy'
+import semver from 'semver'
 import { Key, ChainablePromiseElement } from 'webdriverio'
 
 import logger from '@wdio/logger'
@@ -631,7 +632,8 @@ export class FindWidget extends BasePage<typeof FindWidgetLocators> {
      * Click 'Next match'
      */
     async nextMatch (): Promise<void> {
-        const name = (await browser.getVSCodeVersion()) < '1.59.0' ? 'Next match' : 'Next Match'
+        const version = await browser.getVSCodeVersion()
+        const name = semver.lt(version, '1.59.0') ? 'Next match' : 'Next Match'
         await this.clickButton(name, 'find')
     }
 
@@ -639,7 +641,10 @@ export class FindWidget extends BasePage<typeof FindWidgetLocators> {
      * Click 'Previous match'
      */
     async previousMatch (): Promise<void> {
-        const name = (await browser.getVSCodeVersion()) < '1.59.0' ? 'Previous match' : 'Previous Match'
+        const version = await browser.getVSCodeVersion()
+        const name = semver.lt(version, '1.59.0')
+            ? 'Previous match'
+            : 'Previous Match'
         await this.clickButton(name, 'find')
     }
 

--- a/src/pageobjects/utils.ts
+++ b/src/pageobjects/utils.ts
@@ -228,7 +228,7 @@ export function sleep (ms = 500) {
  * @returns true if version is 'stable' or if version >= targetVersion
  */
 export function semverGte (version: string, targetVersion: string): boolean {
-    if (version === 'stable') {
+    if (version === 'stable' || version === 'insiders') {
         return true
     }
     return semver.gte(version, targetVersion)
@@ -241,7 +241,7 @@ export function semverGte (version: string, targetVersion: string): boolean {
  * @returns true if version is 'stable', otherwise returns version < targetVersion
  */
 export function semverLt (version: string, targetVersion: string): boolean {
-    if (version === 'stable') {
+    if (version === 'stable' || version === 'insiders') {
         return true
     }
     return semver.lt(version, targetVersion)

--- a/src/pageobjects/utils.ts
+++ b/src/pageobjects/utils.ts
@@ -1,5 +1,6 @@
 /* eslint-disable object-shorthand */
 import type { ChainablePromiseElement, ChainablePromiseArray } from 'webdriverio'
+import semver from 'semver'
 
 import * as allLocatorsTypes from '../locators/insiders.js'
 import { ContextMenu } from './index.js'
@@ -218,4 +219,30 @@ export function sleep (ms = 500) {
     return new Promise<void>((res) => {
         setTimeout(res, ms)
     })
+}
+
+/**
+ * Semver utility function that handles the special case where version is 'stable'
+ * @param version The version to compare
+ * @param targetVersion The target version to compare against
+ * @returns true if version is 'stable' or if version >= targetVersion
+ */
+export function semverGte (version: string, targetVersion: string): boolean {
+    if (version === 'stable') {
+        return true
+    }
+    return semver.gte(version, targetVersion)
+}
+
+/**
+ * Semver utility function that handles the special case where version is 'stable'
+ * @param version The version to compare
+ * @param targetVersion The target version to compare against
+ * @returns true if version is 'stable', otherwise returns version < targetVersion
+ */
+export function semverLt (version: string, targetVersion: string): boolean {
+    if (version === 'stable') {
+        return true
+    }
+    return semver.lt(version, targetVersion)
 }

--- a/src/pageobjects/workbench/Workbench.ts
+++ b/src/pageobjects/workbench/Workbench.ts
@@ -1,3 +1,4 @@
+import semver from 'semver'
 import { TitleBar } from '../menu/TitleBar.js'
 import { SideBarView } from '../sidebar/SideBarView.js'
 import { ActivityBar } from '../activityBar/ActivityBar.js'
@@ -192,9 +193,11 @@ export class Workbench extends BasePage<typeof WorkbenchLocators> {
             }
         }
         await browser.keys(['F1'])
+        const version = await browser.getVSCodeVersion()
         if (
-            (await browser.getVSCodeChannel() === 'vscode' && await browser.getVSCodeVersion() >= '1.44.0')
-            || await browser.getVSCodeVersion() === 'insiders'
+            ((await browser.getVSCodeChannel()) === 'vscode'
+                && semver.gte(version, '1.44.0'))
+            || version === 'insiders'
         ) {
             return new InputBox(this.locatorMap).wait()
         }

--- a/src/pageobjects/workbench/Workbench.ts
+++ b/src/pageobjects/workbench/Workbench.ts
@@ -1,4 +1,3 @@
-import semver from 'semver'
 import { TitleBar } from '../menu/TitleBar.js'
 import { SideBarView } from '../sidebar/SideBarView.js'
 import { ActivityBar } from '../activityBar/ActivityBar.js'
@@ -12,7 +11,7 @@ import { SettingsEditor } from '../editor/SettingsEditor.js'
 import { WebView } from './WebView.js'
 
 import {
-    PageDecorator, IPageDecorator, BasePage, sleep
+    PageDecorator, IPageDecorator, BasePage, sleep, semverGte
 } from '../utils.js'
 import { Workbench as WorkbenchLocators } from '../../locators/1.73.0.js'
 
@@ -196,7 +195,7 @@ export class Workbench extends BasePage<typeof WorkbenchLocators> {
         const version = await browser.getVSCodeVersion()
         if (
             ((await browser.getVSCodeChannel()) === 'vscode'
-                && semver.gte(version, '1.44.0'))
+                && semverGte(version, '1.44.0'))
             || version === 'insiders'
         ) {
             return new InputBox(this.locatorMap).wait()


### PR DESCRIPTION
The problem:

```
❯ node
Welcome to Node.js v20.18.1.
Type ".help" for more information.
> '1.102.3' >= '1.44.0'
false
> '1.10.3' >= '1.44.0'
false
> '1.55.3' >= '1.44.0'
true
```

Workaround is to pin an old target VS Code version:

https://github.com/runmedev/vscode-runme/commit/17411fd54055e94885529b5458643a397e76667d