### PR TITLE
perf: migrate to tinyclip from clipboardy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -15,13 +15,13 @@
         "@vscode/test-electron": "^2.3.9",
         "@wdio/logger": "^8.28.0",
         "@xhmikosr/downloader": "^15.0.1",
-        "clipboardy": "^3.0.0",
         "decamelize": "6.0.0",
         "fastify": "^4.26.1",
         "get-port": "7.0.0",
         "hpagent": "^1.2.0",
         "semver": "^7.7.2",
         "slash": "^5.1.0",
+        "tinyclip": "^0.1.12",
         "tmp-promise": "^3.0.3",
         "undici": "^5.28.3",
         "vscode-uri": "^3.0.8",
@@ -60,7 +60,7 @@
         "typescript": "^5.3.3"
       },
       "engines": {
-        "node": "^16.13 || >=18"
+        "node": "^16.14 || >=18"
       },
       "peerDependencies": {
         "webdriverio": "^8.32.2"
@@ -2686,25 +2686,6 @@
         "node": ">= 8"
       }
     },
-    "node_modules/arch": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/arch/-/arch-2.2.0.tgz",
-      "integrity": "sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==",
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
     "node_modules/archiver": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/archiver/-/archiver-7.0.1.tgz",
@@ -3560,93 +3541,6 @@
       "dev": true,
       "engines": {
         "node": ">= 12"
-      }
-    },
-    "node_modules/clipboardy": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/clipboardy/-/clipboardy-3.0.0.tgz",
-      "integrity": "sha512-Su+uU5sr1jkUy1sGRpLKjKrvEOVXgSgiSInwa/qeID6aJ07yh+5NWc3h2QfjHjBnfX4LhtFcuAWKUsJ3r+fjbg==",
-      "dependencies": {
-        "arch": "^2.2.0",
-        "execa": "^5.1.1",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/execa": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/execa/-/execa-5.1.1.tgz",
-      "integrity": "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg==",
-      "dependencies": {
-        "cross-spawn": "^7.0.3",
-        "get-stream": "^6.0.0",
-        "human-signals": "^2.1.0",
-        "is-stream": "^2.0.0",
-        "merge-stream": "^2.0.0",
-        "npm-run-path": "^4.0.1",
-        "onetime": "^5.1.2",
-        "signal-exit": "^3.0.3",
-        "strip-final-newline": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sindresorhus/execa?sponsor=1"
-      }
-    },
-    "node_modules/clipboardy/node_modules/human-signals": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
-      "integrity": "sha512-B4FFZ6q/T2jhhksgkbEW3HBvWIfDW85snkQgawt07S7J5QXTk6BkNV+0yAeZrM5QpMAdYlocGoljn0sJ/WQkFw==",
-      "engines": {
-        "node": ">=10.17.0"
-      }
-    },
-    "node_modules/clipboardy/node_modules/mimic-fn": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-2.1.0.tgz",
-      "integrity": "sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/clipboardy/node_modules/npm-run-path": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-4.0.1.tgz",
-      "integrity": "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==",
-      "dependencies": {
-        "path-key": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/clipboardy/node_modules/onetime": {
-      "version": "5.1.2",
-      "resolved": "https://registry.npmjs.org/onetime/-/onetime-5.1.2.tgz",
-      "integrity": "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==",
-      "dependencies": {
-        "mimic-fn": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/clipboardy/node_modules/strip-final-newline": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/strip-final-newline/-/strip-final-newline-2.0.0.tgz",
-      "integrity": "sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/cliui": {
@@ -7468,20 +7362,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/is-docker": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-2.2.1.tgz",
-      "integrity": "sha512-F+i2BKsFrH66iaUFc0woD8sLy8getkwTwtOBjvs56Cx4CgJDeKQeqfz8wAYiSb8JOprWhHH5p77PbmYCvvUuXQ==",
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -7797,17 +7677,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
-      }
-    },
-    "node_modules/is-wsl": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
-      "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
-      "dependencies": {
-        "is-docker": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/isarray": {
@@ -8866,7 +8735,8 @@
     "node_modules/merge-stream": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/merge-stream/-/merge-stream-2.0.0.tgz",
-      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="
+      "integrity": "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==",
+      "dev": true
     },
     "node_modules/merge2": {
       "version": "1.4.1",
@@ -12337,7 +12207,8 @@
     "node_modules/signal-exit": {
       "version": "3.0.7",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.7.tgz",
-      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="
+      "integrity": "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ==",
+      "dev": true
     },
     "node_modules/simple-concat": {
       "version": "1.0.1",
@@ -12927,6 +12798,15 @@
       "version": "2.3.8",
       "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
       "integrity": "sha512-w89qg7PI8wAdvX60bMDP+bFoD5Dvhm9oLheFp5O4a2QF0cSBGsBX4qZmadPMvVqlLJBBci+WqGGOAPvcDeNSVg=="
+    },
+    "node_modules/tinyclip": {
+      "version": "0.1.12",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.12.tgz",
+      "integrity": "sha512-Ae3OVUqifDw0wBriIBS7yVaW44Dp6eSHQcyq4Igc7eN2TJH/2YsicswaW+J/OuMvhpDPOKEgpAZCjkb4hpoyeA==",
+      "license": "MIT",
+      "engines": {
+        "node": "^16.14.0 || >= 17.3.0"
+      }
     },
     "node_modules/tinyrainbow": {
       "version": "1.2.0",

--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "types": "./dist/index.d.ts",
   "typeScriptVersion": "3.8.3",
   "engines": {
-    "node": "^16.13 || >=18"
+    "node": "^16.14 || >=18"
   },
   "scripts": {
     "build": "run-s build:*",
@@ -48,13 +48,13 @@
     "@vscode/test-electron": "^2.3.9",
     "@wdio/logger": "^8.28.0",
     "@xhmikosr/downloader": "^15.0.1",
-    "clipboardy": "^3.0.0",
     "decamelize": "6.0.0",
     "fastify": "^4.26.1",
     "get-port": "7.0.0",
     "hpagent": "^1.2.0",
     "semver": "^7.7.2",
     "slash": "^5.1.0",
+    "tinyclip": "^0.1.12",
     "tmp-promise": "^3.0.3",
     "undici": "^5.28.3",
     "vscode-uri": "^3.0.8",

--- a/src/pageobjects/bottomBar/Views.ts
+++ b/src/pageobjects/bottomBar/Views.ts
@@ -1,4 +1,4 @@
-import clipboard from 'clipboardy'
+import * as clipboard from 'tinyclip'
 import { Key } from 'webdriverio'
 
 import { Workbench, BottomBarPanel, ContentAssist } from '../../index.js'
@@ -83,8 +83,8 @@ export class DebugConsoleView extends ElementWithContextMenu<typeof DebugConsole
     async getText (): Promise<string> {
         const menu = await this.openContextMenu()
         await menu.select('Copy All')
-        const text = await clipboard.read()
-        await clipboard.write('')
+        const text = await clipboard.readText()
+        await clipboard.writeText('')
         return text
     }
 
@@ -195,13 +195,13 @@ export class TerminalView extends ChannelView<typeof TerminalViewLocators> {
         })
         // eslint-disable-next-line wdio/no-pause
         await browser.pause(500)
-        const text = await clipboard.read()
+        const text = await clipboard.readText()
 
         if (!text && retry > 0) {
             return this.getText(retry - 1)
         }
 
-        clipboard.writeSync('')
+        await clipboard.writeText('')
         return text.trim()
     }
 

--- a/src/pageobjects/editor/TextEditor.ts
+++ b/src/pageobjects/editor/TextEditor.ts
@@ -1,5 +1,5 @@
 import { fileURLToPath } from 'node:url'
-import clipboard from 'clipboardy'
+import * as clipboard from 'tinyclip'
 import { Key, ChainablePromiseElement } from 'webdriverio'
 
 import logger from '@wdio/logger'
@@ -131,11 +131,11 @@ export class TextEditor extends Editor<EditorLocators> {
             .pause(10)
             .up(CMD_KEY).up('a').up('c')
             .perform()
-        const text = clipboard.readSync()
+        const text = await clipboard.readText()
         await browser.action('key')
             .down(Key.ArrowUp).up(Key.ArrowUp)
             .perform()
-        clipboard.writeSync('')
+        await clipboard.writeText('')
 
         /**
          * let's return "" if the editor is empty rather than "\n"
@@ -152,13 +152,13 @@ export class TextEditor extends Editor<EditorLocators> {
      * @returns Promise resolving once the new text is copied over
      */
     async setText (text: string, formatText = false): Promise<void> {
-        clipboard.writeSync(text)
+        await clipboard.writeText(text)
         await browser.action('key')
             .down(CMD_KEY).down('a').down('v')
             .pause(10)
             .up(CMD_KEY).up('a').up('v')
             .perform()
-        clipboard.writeSync('')
+        await clipboard.writeText('')
         if (formatText) {
             await this.formatDocument()
         }
@@ -265,7 +265,7 @@ export class TextEditor extends Editor<EditorLocators> {
             .down(CMD_KEY).down('c')
             .up(CMD_KEY).up('c')
             .perform()
-        return clipboard.read()
+        return clipboard.readText()
     }
 
     /**

--- a/src/pageobjects/workbench/Input.ts
+++ b/src/pageobjects/workbench/Input.ts
@@ -1,4 +1,4 @@
-import clipboard from 'clipboardy'
+import * as clipboard from 'tinyclip'
 import { Key } from 'webdriverio'
 
 import {
@@ -53,7 +53,7 @@ export abstract class Input extends BasePage<AllInputLocators> {
         // fallback to clipboard if the text gets malformed
         const currentText = await this.getText()
         if (currentText !== text) {
-            await clipboard.write(text)
+            await clipboard.writeText(text)
             if (currentText?.length) {
                 const backSpaces: string[] = new Array(currentText.length).fill(Key.Backspace)
                 const keyAction = browser.action('key')
@@ -62,7 +62,7 @@ export abstract class Input extends BasePage<AllInputLocators> {
                 }
                 await keyAction.perform()
             }
-            await clipboard.write('')
+            await clipboard.writeText('')
         }
     }
 


### PR DESCRIPTION
Tinyclip is [really lighter](https://npmx.dev/compare?packages=tinyclip,clipboardy) than clipboardy. This PR was made as part of the [e18e initiative](https://e18e.dev/).