### PR TITLE
fix: strip ChromeDriver-only flags before passing argv to VS Code binary

### DIFF
--- a/src/chromium/index.ts
+++ b/src/chromium/index.ts
@@ -34,12 +34,52 @@ function run (p: NodeJS.Process, execFile: typeof childProcess.execFile) {
         throw new Error('Missing parameter "--vscode-binary-path=/..."')
     }
 
-    const params = Object.entries(argv).map(([key, value]) => {
-        if (typeof value === 'boolean' && value) {
-            return `--${key}`
-        }
-        return `--${key}=${value}`
-    })
+    /**
+     * Flags injected by ChromeDriver that VS Code's Electron binary does not recognise.
+     * Passing them causes onUnknownOption → console.warn → EPIPE → crash (see issue #60).
+     */
+    const CHROMIUM_ONLY_FLAGS = new Set([
+        // Added by ChromeDriver automatically
+        'log-level', 'test-type', 'password-store', 'use-mock-keychain',
+        'no-service-autorun', 'no-first-run', 'enable-automation',
+        'remote-debugging-address', 'flag-switches-begin', 'flag-switches-end',
+        'disable-field-trial-config', 'allow-pre-commit-input',
+        'origin-trial-disabled-features', 'variations-seed-version',
+        // Chrome-specific behaviour flags passed by wdio-vscode-service Chrome options
+        'disable-background-networking', 'disable-client-side-phishing-detection',
+        'disable-default-apps', 'disable-hang-monitor', 'disable-popup-blocking',
+        'disable-prompt-on-repost', 'disable-sync', 'disable-updates',
+        // Chrome-specific: must NOT reach VS Code (conflicts with disableExtensions: false)
+        'disable-extensions',
+        // Chrome feature-flag overrides — not valid VS Code CLI flags
+        'enable-features', 'disable-features',
+    ])
+
+    const params = Object.entries(argv)
+        .filter(([key, value]) =>
+            // yargs-parser produces both kebab-case and camelCase keys; drop the camelCase duplicates
+            !/[A-Z]/.test(key) &&
+            // drop the internal routing flag consumed above
+            key !== 'vscode-binary-path' &&
+            // drop ChromeDriver-injected flags that VS Code doesn't understand
+            !CHROMIUM_ONLY_FLAGS.has(key) &&
+            // drop flags explicitly set to false / 'false'
+            value !== false &&
+            value !== 'false'
+        )
+        .flatMap(([key, value]) => {
+            // Array values (e.g. extensionDevelopmentPath) → one --flag=val per element
+            if (Array.isArray(value)) {
+                const items = (value as unknown[]).filter((v) => v !== false && v !== 'false')
+                return items.map((v) =>
+                    typeof v === 'boolean' && v ? `--${key}` : `--${key}=${v}`
+                )
+            }
+            if (typeof value === 'boolean' && value) {
+                return [`--${key}`]
+            }
+            return [`--${key}=${value}`]
+        })
     const args: string[] = [...params, ...positionalParams.map(String)]
 
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Related

Fixes #60 (extension host EPIPE crash caused by `onUnknownOption → console.warn`)

## Problem

ChromeDriver automatically injects a large set of flags when it launches what it thinks is a Chrome binary — flags like `--disable-extensions`, `--enable-automation`, `--test-type`, `--log-level`, `--password-store`, etc. VS Code's Electron binary does not recognise these flags, so each one triggers an `onUnknownOption` handler that calls `console.warn`, which in turn causes an EPIPE write error that can crash the extension host. This is the root cause of issue #60.

Three related bugs in the fake-Chrome wrapper are fixed:

1. **Chrome-only flags leak through to VS Code** — `--disable-extensions` in particular conflicts with `disableExtensions: false` in your wdio config, silently re-disabling extensions even when you've explicitly opted in.

2. **camelCase key duplicates** — `yargs-parser` is configured with `camel-case-expansion: true`, so every kebab-case flag produces *two* entries in `argv` (e.g. both `vscode-binary-path` and `vscodeBinaryPath`). The camelCase duplicates were being emitted as `--vscodeBinaryPath=...` etc., which VS Code also rejects.

3. **Array-valued flags** (e.g. `extensionDevelopmentPath` when testing multiple extensions) were being serialised as a single `--flag=val1,val2` string. They should be expanded to one `--flag=val` argument per element.

## Changes

- Add `CHROMIUM_ONLY_FLAGS` set covering all flags ChromeDriver and wdio-vscode-service Chrome options inject automatically
- Filter out camelCase duplicate keys (`/[A-Z]/` test) and the internal `vscode-binary-path` routing key
- Filter out `false` / `'false'` flag values (boolean negation via `--no-foo` should set the flag to false, not emit `--foo=false`)
- Expand array values to individual `--flag=val` arguments, dropping any `false`/`'false'` elements within the array