### PR TITLE
Support worker-specific VSCode workspaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,7 +191,19 @@ Default: `{}`
 
 Opens VSCode for a specific workspace. If not provided VSCode starts without a workspace opened.
 
-Type: `string`
+For desktop sessions this can also be a callback that resolves the workspace path
+for the current WDIO worker. This is useful when suites run in parallel and each
+suite needs an isolated workspace directory:
+
+```ts
+workspacePath: ({ cid, specs }) => getWorkspaceForSuite(cid, specs)
+```
+
+The callback is resolved before each worker starts. Web extension sessions require
+a static string because the shared VSCode Web server is started before workers are
+available.
+
+Type: `string | ({ config, capabilities, specs, cid }) => string | undefined | Promise<string | undefined>`
 
 #### `filePath`
 

--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -7,7 +7,7 @@ import logger from '@wdio/logger'
 import { setGlobalDispatcher, request, ProxyAgent } from 'undici'
 import { download } from '@vscode/test-electron'
 import { SevereServiceError } from 'webdriverio'
-import type { Capabilities } from '@wdio/types'
+import type { Capabilities, Options } from '@wdio/types'
 import { HttpsProxyAgent } from 'hpagent'
 
 import startServer from './server/index.js'
@@ -104,6 +104,25 @@ export default class VSCodeServiceLauncher {
         }
     }
 
+    async onWorkerStart (
+        cid: string,
+        caps: VSCodeCapabilities,
+        specs: string[],
+        args: Options.Testrunner
+    ) {
+        const vscodeOptions = caps[VSCODE_CAPABILITY_KEY]
+        if (typeof vscodeOptions?.workspacePath !== 'function') {
+            return
+        }
+
+        vscodeOptions.workspacePath = await vscodeOptions.workspacePath({
+            config: args,
+            capabilities: caps,
+            specs,
+            cid
+        })
+    }
+
     /**
      * Set up VSCode for web testing
      * @param versionsFileExist true if we already have information stored about cached VSCode bundles
@@ -114,6 +133,12 @@ export default class VSCodeServiceLauncher {
         version: string,
         cap: VSCodeCapabilities
     ) {
+        if (typeof cap[VSCODE_CAPABILITY_KEY]?.workspacePath === 'function') {
+            throw new SevereServiceError(
+                'workspacePath callbacks are only supported for VSCode Desktop sessions'
+            )
+        }
+
         /**
          * no need to do any work if we already started the server
          */

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -36,6 +36,10 @@ type COIRequest = FastifyRequest<{
 export default async function startServer (standalone: Bundle, options: VSCodeOptions) {
     const app = fastify({ logger: true })
     const port = await getPort({ port: options.serverOptions?.port || DEFAULT_VSCODE_WEB_PORT })
+    const workspacePath = typeof options.workspacePath === 'string'
+        ? options.workspacePath
+        : undefined
+
     await app.register(fastifyCors, {
         methods: ['GET'],
         credentials: true,
@@ -75,18 +79,18 @@ export default async function startServer (standalone: Bundle, options: VSCodeOp
         decorateReply: false // the reply decorator has been added by the first plugin registration
     })
 
-    if (options.workspacePath) {
-        log.info(`Serve workspace from ${options.workspacePath}`)
+    if (workspacePath) {
+        log.info(`Serve workspace from ${workspacePath}`)
         app.addHook('preHandler', async (req, reply) => {
             const filePath = (req.params as { '*': string })['*']
             const queries = Object.keys(req.query as Record<string, string>)
 
-            if (!options.workspacePath || !filePath || !req.url.startsWith(mountPrefix)) {
+            if (!filePath || !req.url.startsWith(mountPrefix)) {
                 return null
             }
 
             const p = path.join(
-                options.workspacePath,
+                workspacePath,
                 filePath === mountPrefix.slice(1)
                     ? filePath.slice(mountPrefix.length - 1)
                     : filePath
@@ -129,7 +133,7 @@ export default async function startServer (standalone: Bundle, options: VSCodeOp
 
         await app.register(fastifyStatic, {
             prefix: `${mountPrefix}/`,
-            root: options.workspacePath,
+            root: workspacePath,
             dotfiles: 'allow',
             decorateReply: false // the reply decorator has been added by the first plugin registration
         })
@@ -183,7 +187,7 @@ export default async function startServer (standalone: Bundle, options: VSCodeOp
                 },
                 extensionTestsPath: undefined,
                 folderUri: undefined,
-                folderMountPath: options.workspacePath,
+                folderMountPath: workspacePath,
                 printServerLog: true
             }
         )

--- a/src/service.ts
+++ b/src/service.ts
@@ -32,6 +32,7 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
     private _promisedSocket?: Promise<WebSocket>
     private _proxyOptions: VSCodeProxyOptions
     private _vscodeOptions: VSCodeOptions
+    private _workspacePath?: string
     private _isWebSession = false
     private _isCucumberSession = false
     private _deletingSession = false
@@ -71,7 +72,31 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         this._pendingMessages.forEach((resolver) => resolver(msg, null))
     }
 
-    async beforeSession (option: Options.Testrunner, capabilities: VSCodeCapabilities) {
+    private async _resolveWorkspacePath (
+        config: Options.Testrunner,
+        capabilities: VSCodeCapabilities,
+        specs: string[],
+        cid: string
+    ) {
+        const { workspacePath } = this._vscodeOptions
+        if (typeof workspacePath !== 'function') {
+            return workspacePath
+        }
+
+        return workspacePath({
+            config,
+            capabilities,
+            specs,
+            cid
+        })
+    }
+
+    async beforeSession (
+        option: Options.Testrunner,
+        capabilities: VSCodeCapabilities,
+        specs: string[] = [],
+        cid = ''
+    ) {
         this._isWebSession = capabilities.browserName !== 'vscode'
         this._isCucumberSession = option.framework === 'cucumber'
 
@@ -81,6 +106,8 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
         if (!isVSCodeCapability(capabilities)) {
             return
         }
+
+        this._workspacePath = await this._resolveWorkspacePath(option, capabilities, specs, cid)
 
         /**
          * if we run tests for a web extension
@@ -144,8 +171,8 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
             'utf-8'
         )
 
-        if (this._vscodeOptions.workspacePath) {
-            customArgs.folderUri = `file:${slash(this._vscodeOptions.workspacePath)}`
+        if (this._workspacePath) {
+            customArgs.folderUri = `file:${slash(this._workspacePath)}`
         }
 
         if (this._vscodeOptions.filePath) {
@@ -220,8 +247,8 @@ export default class VSCodeWorkerService implements Services.ServiceInstance {
          * VSCode in the browser doesn't allow to have a file directly opened,
          * therefore we need to open it automatically
          */
-        if (this._isWebSession && this._vscodeOptions.filePath && this._vscodeOptions.workspacePath) {
-            const sections = this._vscodeOptions.filePath.replace(this._vscodeOptions.workspacePath, '')
+        if (this._isWebSession && this._vscodeOptions.filePath && this._workspacePath) {
+            const sections = this._vscodeOptions.filePath.replace(this._workspacePath, '')
                 .split(path.sep).filter(Boolean)
             const fileExplorer = await browser.$('.explorer-folders-view')
             while (sections.length > 0) {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { Options } from '@wdio/types'
+
 import type { VSCODE_CAPABILITY_KEY } from './constants.js'
 
 /**
@@ -69,6 +71,29 @@ export interface BundleInformation {
     path: string
 }
 
+export interface WorkspacePathResolverContext {
+    /**
+     * WDIO runner config for the worker that is starting the VS Code session.
+     */
+    config: Options.Testrunner
+    /**
+     * Capabilities for the worker that is starting the VS Code session.
+     */
+    capabilities: VSCodeCapabilities
+    /**
+     * Specs assigned to the current worker.
+     */
+    specs: string[]
+    /**
+     * WDIO worker id.
+     */
+    cid: string
+}
+
+export type WorkspacePathResolver = (
+    context: WorkspacePathResolverContext
+) => string | undefined | Promise<string | undefined>
+
 /**
  * Options to manage VSCode session as part of session capability
  */
@@ -94,9 +119,11 @@ export interface VSCodeOptions {
      */
     userSettings?: Record<string, number | string | object | boolean>
     /**
-     * Opens VSCode for a specific workspace
+     * Opens VSCode for a specific workspace.
+     * Use a callback to resolve a worker-specific workspace path when running
+     * suites in parallel.
      */
-    workspacePath?: string
+    workspacePath?: string | WorkspacePathResolver
     /**
      * Opens VSCode with a specific file opened
      */

--- a/test/wdio.conf.ts
+++ b/test/wdio.conf.ts
@@ -7,6 +7,7 @@ import type { VSCodeCapabilities } from '../dist/types'
 const __dirname = url.fileURLToPath(new URL('.', import.meta.url))
 const grep = []
 const isWebTest = Boolean(parseInt(process.env.VSCODE_WEB_TESTS || '', 10))
+const workspacePath = path.join(__dirname, '..')
 const capabilities: VSCodeCapabilities = {
     ...(isWebTest
         ? {
@@ -22,8 +23,13 @@ const capabilities: VSCodeCapabilities = {
     ),
     'wdio:vscodeOptions': {
         extensionPath: path.join(__dirname, 'extension'),
-        workspacePath: path.join(__dirname, '..'),
-        filePath: path.join(__dirname, '..', 'README.md'),
+        workspacePath: isWebTest ? workspacePath : ({ cid, specs }) => {
+            if (!cid || specs.length === 0) {
+                throw new Error('Expected worker context when resolving workspace path')
+            }
+            return workspacePath
+        },
+        filePath: path.join(workspacePath, 'README.md'),
         userSettings: {
             'terminal.integrated.cwd': `${path.join(__dirname, '..')}`,
             'terminal.integrated.profiles.windows': {


### PR DESCRIPTION
## Summary
- allow `wdio:vscodeOptions.workspacePath` to be a resolver callback for VSCode desktop sessions
- resolve callback values in the launcher before WDIO serializes worker capabilities
- keep VSCode Web workspace mounting on static string paths and fail clearly for callback usage there
- document the resolver context and cover it in the local WDIO config

Closes #132

## Verification
- `mise x node@18.20.2 -- npm run build`
- `mise x node@18.20.2 -- npm run test:lint`
- `git diff --check`
- `mise x node@18.20.2 -- npx wdio run ./test/wdio.conf.ts --spec ./test/specs/activitybar.e2e.ts --logLevel info`