### PR TITLE
fix: normalize VS Code version for cgmanifest.json lookup

### DIFF
--- a/src/launcher.ts
+++ b/src/launcher.ts
@@ -243,9 +243,13 @@ export default class VSCodeServiceLauncher {
      */
     private async _fetchChromedriverVersion (vscodeVersion: string) {
         try {
+            // VS Code only tags .0 releases on GitHub (e.g. 1.122.0), not patch
+            // releases (e.g. 1.122.1). The Chromium version is the same across
+            // patch releases, so normalize to .0 for the manifest lookup.
+            const normalizedVersion = vscodeVersion.replace(/^(\d+\.\d+)\.\d+$/, '$1.0')
             const manifestUrl = vscodeVersion.includes('insider')
                 ? VSCODE_INSIDER_MANIFEST_URL
-                : format(VSCODE_MANIFEST_URL, vscodeVersion)
+                : format(VSCODE_MANIFEST_URL, normalizedVersion)
 
             log.info(`manifest url: ${manifestUrl}`)
             const { body } = await request(manifestUrl, {})


### PR DESCRIPTION
## Problem

When `browserVersion` resolves to a VS Code patch release (e.g. `1.122.1`), `_fetchChromedriverVersion` crashes with:

```
SevereServiceError: Couldn't fetch Chromedriver version: Unexpected non-whitespace character after JSON at position 3
```

VS Code only creates Git tags for `.0` releases on GitHub. Patch release tags (e.g. `1.122.1`) don't exist, so fetching `cgmanifest.json` from `https://raw.githubusercontent.com/microsoft/vscode/1.122.1/cgmanifest.json` returns a 404 plain text response that `body.json()` can't parse.

```
$ curl -sI https://raw.githubusercontent.com/microsoft/vscode/1.122.0/cgmanifest.json
HTTP/2 200

$ curl -sI https://raw.githubusercontent.com/microsoft/vscode/1.122.1/cgmanifest.json
HTTP/2 404
```

## Fix

Strip the patch component before constructing the manifest URL (`1.122.1` → `1.122.0`). The Chromium version is identical across patch releases, so this is safe. Non-semver strings like `"insiders"` pass through the regex unchanged.

Fixes #157